### PR TITLE
Rerun uniffi if changed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,6 @@ jobs:
         run: cargo build --verbose
       - name: Run unit tests
         run: cargo test --verbose
-      - name: Build examples
-        run: cargo build --verbose --examples
       - name: Verify if bindings change
         uses: tj-actions/verify-changed-files@v11.1
         id: verify-bindings

--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,11 @@ use camino::Utf8Path;
 use std::env;
 
 fn main() {
+    let udl_file = Utf8Path::new("src/lipalightninglib.udl");
+    println!("cargo:rerun-if-changed={}", udl_file);
+
     uniffi_bindgen::generate_component_scaffolding(
-        Utf8Path::new("src/lipalightninglib.udl"),
+        udl_file,
         None,
         Some(Utf8Path::new(&env::var("OUT_DIR").unwrap())),
         false,
@@ -11,7 +14,7 @@ fn main() {
     .unwrap();
 
     uniffi_bindgen::generate_bindings(
-        Utf8Path::new("src/lipalightninglib.udl"),
+        udl_file,
         None,
         Vec::from(["swift"]),
         Some(Utf8Path::new("bindings/swift")),
@@ -21,7 +24,7 @@ fn main() {
     .unwrap();
 
     uniffi_bindgen::generate_bindings(
-        Utf8Path::new("src/lipalightninglib.udl"),
+        udl_file,
         None,
         Vec::from(["kotlin"]),
         Some(Utf8Path::new("bindings/kotlin")),


### PR DESCRIPTION
- Rerun uniffi only when the source changed
- Remove `Build examples` since examples are build with tests