### PR TITLE
Add StorageCallback interface

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -21,3 +21,35 @@ pub trait PersistCallback: Send + Sync + Debug {
     /// Read data from file
     fn read(&self, path: String) -> Vec<u8>;
 }
+
+pub trait RedundantStorageCallback: Send + Sync + Debug {
+    fn object_exists(&self, bucket: String, key: String) -> bool;
+
+    fn get_object(&self, bucket: String, key: String) -> Vec<u8>;
+
+    /// Check health of the local and remote storage.
+    /// The library will likely call this method before starting a transaction.
+    /// Hint: request and cache an access tocken if needed.
+    ///
+    /// Returning `false` for `monitors` bucket will likely result in the
+    /// library rejecting to start a transaction.
+    fn check_health(&self, bucket: String) -> bool;
+
+    /// Atomically put an object in the bucket (create the bucket if it does not exists).
+    ///
+    /// # Return
+    /// Returns `true` if successful and `false` otherwise.
+    ///
+    /// Must only return after being certain that data was persisted safely.
+    /// Failure to do so for `monitors` bucket may result in loss of funds.
+    ///
+    /// Returning `false` for `monitors` bucket will likely result in a channel
+    /// being force-closed.
+    fn put_object(&self, bucket: String, key: String, value: Vec<u8>) -> bool;
+
+    /// List objects in the given bucket.
+    ///
+    /// # Return
+    /// Return a list of object keys present in the bucket.
+    fn list_objects(&self, bucket: String) -> Vec<String>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ mod util;
 
 use crate::bitcoind_client::BitcoindClient;
 use crate::callbacks::PersistCallback;
+use crate::callbacks::RedundantStorageCallback;
 use crate::config::LipaLightningConfig;
 use crate::electrum_client::ElectrumClient;
 use crate::errors::LipaLightningError;

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -22,6 +22,14 @@ callback interface PersistCallback {
     sequence<u8> read(string path);
 };
 
+callback interface RedundantStorageCallback {
+    boolean object_exists(string bucket, string key);
+    sequence<u8> get_object(string bucket, string key);
+    boolean check_health(string bucket);
+    boolean put_object(string bucket, string key, sequence<u8> value);
+    sequence<string> list_objects(string bucket);
+};
+
 dictionary LipaNodeInfo {
     sequence<u8> node_pubkey;
     u64 num_channels;


### PR DESCRIPTION
Hi.

Please have a look at the proposed interface for persistence callback. Seems that we do not need a full-featured file system access, so we can limit our API to a key-value storage.
Mobile devs please check if you can easily implement such interface.
Lightning devs please make sure that such interface would be enough for our needs.