### PR TITLE
Fix missing `.ldk` folder error on example node

### DIFF
--- a/examples/node/main.rs
+++ b/examples/node/main.rs
@@ -169,6 +169,7 @@ fn main() {
 }
 
 fn init_logger() {
+    fs::create_dir_all(".ldk").unwrap();
     let log_file = fs::OpenOptions::new()
         .create(true)
         .append(true)

--- a/examples/node/main.rs
+++ b/examples/node/main.rs
@@ -119,6 +119,9 @@ fn main() {
     .status()
     .expect("Failed to start nigiri.");*/
 
+    // Create dir for node data persistence
+    fs::create_dir_all(".ldk").unwrap();
+
     init_logger();
 
     let persist_callback = Box::new(RustPersistCallback {});
@@ -169,7 +172,6 @@ fn main() {
 }
 
 fn init_logger() {
-    fs::create_dir_all(".ldk").unwrap();
     let log_file = fs::OpenOptions::new()
         .create(true)
         .append(true)


### PR DESCRIPTION
This solves the issue that if there's no `.ldk` folder on the root dir of the project, then the example node panics. 