### PR TITLE
Stop running CI jobs on tag push + Trigger JitPack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Build and Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,5 +1,11 @@
-on: [push, pull_request]
 name: Static code analysis
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
 jobs:
   security-audit:
     name: Security audit

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -305,3 +305,6 @@ jobs:
             --title "${{ env.RELEASE_VERSION }}" \
             --notes "This pre-release was created automatically by the lipa bot. For more information, please access the corresponding release in https://github.com/getlipa/lipa-lightning-lib" \
             --prerelease
+      - name: Trigger JitPack build
+        run: |
+          curl -s -m 30 https://jitpack.io/com/github/getlipa/lipa-lightning-lib-android/${{ env.RELEASE_VERSION }} || true


### PR DESCRIPTION
The `build` and `code-analysis` actions were performed after a tag push, meaning they were done twice: one for the original push and another when a tag was pushed. Now they are only done on `push` when it's a push related to a branch.

Also, `curl` is set up to trick JitPack into thinking we are requesting the android library so that it's built ahead of time.