### PR TITLE
Verify library binaries

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -267,12 +267,20 @@ jobs:
           
           cp ../bindings/kotlin/uniffi/lipalightninglib/lipalightninglib.kt LipaLightningLib/src/main/java/com/getlipa/lipalightninglib/lipalightninglib.kt
           
-          mv ../target/aarch64-linux-android/release/libuniffi_lipalightninglib.so libuniffi_lipalightninglib_arm64.so
-          mv ../target/armv7-linux-androideabi/release/libuniffi_lipalightninglib.so libuniffi_lipalightninglib_armeabi.so
-          mv ../target/i686-linux-android/release/libuniffi_lipalightninglib.so libuniffi_lipalightninglib_x86.so
+          mkdir -p jniLibs/arm64
+          mkdir -p jniLibs/arm64-v8a
+          mkdir -p jniLibs/armeabi
+          mkdir -p jniLibs/x86
+          cp ../target/aarch64-linux-android/release/libuniffi_lipalightninglib.so jniLibs/arm64
+          cp ../target/aarch64-linux-android/release/libuniffi_lipalightninglib.so jniLibs/arm64-v8a
+          cp ../target/armv7-linux-androideabi/release/libuniffi_lipalightninglib.so jniLibs/armeabi
+          cp ../target/i686-linux-android/release/libuniffi_lipalightninglib.so jniLibs/x86
+          zip -r jniLibs.zip jniLibs
+          shasum -a 256 jniLibs.zip | sed 's/ .*//' > checksum
 
           cp jitpack.yml.template jitpack.yml
           sed -i "s/to_replace_release_version/${{ env.RELEASE_VERSION }}/g" jitpack.yml
+          sed -i "s/to_replace_zip_checksum/$(cat checksum)/g" jitpack.yml
 
           git add LipaLightningLib/src/main/java/com/getlipa/lipalightninglib/lipalightninglib.kt
           git add jitpack.yml
@@ -287,9 +295,7 @@ jobs:
         run: |
           cd lipa-lightning-lib-android
           gh release create ${{ env.RELEASE_VERSION }} \
-            libuniffi_lipalightninglib_arm64.so \
-            libuniffi_lipalightninglib_armeabi.so \
-            libuniffi_lipalightninglib_x86.so \
+            jniLibs.zip \
             --title "${{ env.RELEASE_VERSION }}" \
             --notes "This release was created automatically by the lipa bot. For more information, please access the corresponding release in https://github.com/getlipa/lipa-lightning-lib"
       - name: Create pre-release
@@ -299,9 +305,7 @@ jobs:
         run: |
           cd lipa-lightning-lib-android
           gh release create ${{ env.RELEASE_VERSION }} \
-            libuniffi_lipalightninglib_arm64.so \
-            libuniffi_lipalightninglib_armeabi.so \
-            libuniffi_lipalightninglib_x86.so \
+            jniLibs.zip \
             --title "${{ env.RELEASE_VERSION }}" \
             --notes "This pre-release was created automatically by the lipa bot. For more information, please access the corresponding release in https://github.com/getlipa/lipa-lightning-lib" \
             --prerelease


### PR DESCRIPTION
Fail the JitPack build if the binaries downloaded from the releases page don't have the expected sha256 hash.

This PR should be reviewed together with https://github.com/getlipa/lipa-lightning-lib-android/pull/3.