### PR TITLE
Init persister

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,9 @@ impl LightningNode {
         if !persister.check_monitor_storage_health() {
             warn!("Monitor storage is unhealty");
         }
+        if !persister.check_object_storage_health() {
+            warn!("Object storage is unhealty");
+        }
 
         // Step 5. Initialize the ChainMonitor
 
@@ -51,12 +54,14 @@ impl LightningNode {
         let _channel_monitors = persister.read_channel_monitors();
 
         // Step 8. Initialize the ChannelManager
+        let _channel_manager = persister.read_channel_manager();
 
         // Step 9. Sync ChannelMonitors and ChannelManager to chain tip
 
         // Step 10. Give ChannelMonitors to ChainMonitor
 
         // Step 11: Optional: Initialize the NetGraphMsgHandler
+        let _graph = persister.read_graph();
 
         // Step 12. Initialize the PeerManager
 
@@ -67,10 +72,12 @@ impl LightningNode {
         // Step 15. Initialize an EventHandler
 
         // Step 16. Initialize the ProbabilisticScorer
+        let _scorer = persister.read_scorer();
 
         // Step 17. Initialize the InvoicePayer
 
         // Step 18. Initialize the Persister
+        // Persister trait already implemented and instantiated ("persister")
 
         // Step 19. Start Background Processing
 

--- a/src/storage_persister.rs
+++ b/src/storage_persister.rs
@@ -62,7 +62,6 @@ impl StoragePersister {
 
     fn persist_object(&self, bucket: String, key: String, data: Vec<u8>) -> Result<(), Error> {
         if !self.storage.put_object(bucket, key, data) {
-            // Operating System I/O Error
             return Err(Error::new(
                 io::ErrorKind::Other,
                 "Failed to persist object using storage callback",

--- a/src/storage_persister.rs
+++ b/src/storage_persister.rs
@@ -40,7 +40,7 @@ impl StoragePersister {
     }
 
     pub fn check_object_storage_health(&self) -> bool {
-        self.storage.check_health(OBJECT_BUCKET.to_string())
+        self.storage.check_health(OBJECTS_BUCKET.to_string())
     }
 
     pub fn read_channel_monitors(&self) {
@@ -111,7 +111,7 @@ where
         channel_manager: &ChannelManager<Signer, M, T, K, F, L>,
     ) -> Result<(), Error> {
         self.persist_object(
-            OBJECT_BUCKET.to_string(),
+            OBJECTS_BUCKET.to_string(),
             MANAGER_KEY.to_string(),
             channel_manager.encode(),
         )
@@ -119,7 +119,7 @@ where
 
     fn persist_graph(&self, network_graph: &NetworkGraph<L>) -> Result<(), Error> {
         self.persist_object(
-            OBJECT_BUCKET.to_string(),
+            OBJECTS_BUCKET.to_string(),
             GRAPH_KEY.to_string(),
             network_graph.encode(),
         )
@@ -127,7 +127,7 @@ where
 
     fn persist_scorer(&self, scorer: &S) -> Result<(), Error> {
         self.persist_object(
-            OBJECT_BUCKET.to_string(),
+            OBJECTS_BUCKET.to_string(),
             SCORER_KEY.to_string(),
             scorer.encode(),
         )

--- a/src/storage_persister.rs
+++ b/src/storage_persister.rs
@@ -1,16 +1,30 @@
 use bitcoin::hashes::hex::ToHex;
+use lightning::chain;
+use lightning::chain::chaininterface::{BroadcasterInterface, FeeEstimator};
 use lightning::chain::chainmonitor::MonitorUpdateId;
 use lightning::chain::chainmonitor::Persist;
 use lightning::chain::channelmonitor::ChannelMonitor;
 use lightning::chain::channelmonitor::ChannelMonitorUpdate;
-use lightning::chain::keysinterface::Sign;
+use lightning::chain::keysinterface::{KeysInterface, Sign};
 use lightning::chain::transaction::OutPoint;
 use lightning::chain::ChannelMonitorUpdateErr;
+use lightning::ln::channelmanager::ChannelManager;
+use lightning::routing::gossip::NetworkGraph;
+use lightning::routing::scoring::WriteableScore;
+use lightning::util::logger::Logger;
+use lightning::util::persist::Persister;
 use lightning::util::ser::Writeable;
+use std::io::Error;
+use std::ops::Deref;
 
 use crate::callbacks::RedundantStorageCallback;
 
 static MONITORS_BUCKET: &str = "monitors";
+static OBJECT_BUCKET: &str = "objects";
+
+static MANAGER_KEY: &str = "manager";
+static GRAPH_KEY: &str = "graph";
+static SCORER_KEY: &str = "scorer";
 
 pub struct StoragePersister {
     storage: Box<dyn RedundantStorageCallback>,
@@ -25,8 +39,32 @@ impl StoragePersister {
         self.storage.check_health(MONITORS_BUCKET.to_string())
     }
 
+    pub fn check_object_storage_health(&self) -> bool {
+        self.storage.check_health(OBJECT_BUCKET.to_string())
+    }
+
     pub fn read_channel_monitors(&self) {
         // TODO: Implement
+    }
+
+    pub fn read_channel_manager(&self) {
+        // TODO: Implement
+    }
+
+    pub fn read_graph(&self) {
+        // TODO: Implement
+    }
+
+    pub fn read_scorer(&self) {
+        // TODO: Implement
+    }
+
+    fn persist_object(&self, bucket: String, key: String, data: Vec<u8>) -> Result<(), Error> {
+        if !self.storage.put_object(bucket, key, data) {
+            // Operating System I/O Error
+            return Err(Error::from_raw_os_error(5));
+        }
+        Ok(())
     }
 }
 
@@ -56,6 +94,43 @@ impl<ChannelSigner: Sign> Persist<ChannelSigner> for StoragePersister {
         update_id: MonitorUpdateId,
     ) -> Result<(), ChannelMonitorUpdateErr> {
         self.persist_new_channel(funding_txo, monitor, update_id)
+    }
+}
+
+impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref, S: WriteableScore<'a>>
+    Persister<'a, Signer, M, T, K, F, L, S> for StoragePersister
+where
+    M::Target: 'static + chain::Watch<Signer>,
+    T::Target: 'static + BroadcasterInterface,
+    K::Target: 'static + KeysInterface<Signer = Signer>,
+    F::Target: 'static + FeeEstimator,
+    L::Target: 'static + Logger,
+{
+    fn persist_manager(
+        &self,
+        channel_manager: &ChannelManager<Signer, M, T, K, F, L>,
+    ) -> Result<(), Error> {
+        self.persist_object(
+            OBJECT_BUCKET.to_string(),
+            MANAGER_KEY.to_string(),
+            channel_manager.encode(),
+        )
+    }
+
+    fn persist_graph(&self, network_graph: &NetworkGraph<L>) -> Result<(), Error> {
+        self.persist_object(
+            OBJECT_BUCKET.to_string(),
+            GRAPH_KEY.to_string(),
+            network_graph.encode(),
+        )
+    }
+
+    fn persist_scorer(&self, scorer: &S) -> Result<(), Error> {
+        self.persist_object(
+            OBJECT_BUCKET.to_string(),
+            SCORER_KEY.to_string(),
+            scorer.encode(),
+        )
     }
 }
 
@@ -97,5 +172,6 @@ mod test {
     fn test_out_point() {
         let persister = StoragePersister::new(Box::new(StorageMock {}));
         assert!(persister.check_monitor_storage_health());
+        assert!(persister.check_object_storage_health());
     }
 }

--- a/src/storage_persister.rs
+++ b/src/storage_persister.rs
@@ -20,7 +20,7 @@ use std::ops::Deref;
 use crate::callbacks::RedundantStorageCallback;
 
 static MONITORS_BUCKET: &str = "monitors";
-static OBJECT_BUCKET: &str = "objects";
+static OBJECTS_BUCKET: &str = "objects";
 
 static MANAGER_KEY: &str = "manager";
 static GRAPH_KEY: &str = "graph";

--- a/src/storage_persister.rs
+++ b/src/storage_persister.rs
@@ -14,6 +14,7 @@ use lightning::routing::scoring::WriteableScore;
 use lightning::util::logger::Logger;
 use lightning::util::persist::Persister;
 use lightning::util::ser::Writeable;
+use std::io;
 use std::io::Error;
 use std::ops::Deref;
 
@@ -62,7 +63,10 @@ impl StoragePersister {
     fn persist_object(&self, bucket: String, key: String, data: Vec<u8>) -> Result<(), Error> {
         if !self.storage.put_object(bucket, key, data) {
             // Operating System I/O Error
-            return Err(Error::from_raw_os_error(5));
+            return Err(Error::new(
+                io::ErrorKind::Other,
+                "Failed to persist object using storage callback",
+            ));
         }
         Ok(())
     }


### PR DESCRIPTION
This assumes that we use the same persistence callback for `ChannelMonitors` and the other objects that need to be persisted (e.g. `ChannelManager`, `NetworkGraph`, ...). 