### PR TITLE
Add detached Esplora client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ bitcoin = "0.28.1"
 lightning = { version = "0.0.110", features = ["max_level_trace"] }
 log = "0.4.17"
 rand = "0.8.5"
+reqwest = { version = "0.11", features = ["json", "socks"] }
+serde = "1.0.144"
 thiserror = "1.0.34"
 tokio = { version = "1.21.1", features = ["rt-multi-thread", "time"] }
 uniffi = "0.20.0"

--- a/src/esplora_client.rs
+++ b/src/esplora_client.rs
@@ -1,0 +1,186 @@
+// This file is for the most part a copy from here:
+// https://github.com/bitcoindevkit/rust-esplora-client/blob/master/src/async.rs
+//
+// Once the functionality has been merged into BDK, we should import the functionality from there,
+// respectively use the rust-esplora-client: https://github.com/bitcoindevkit/rust-esplora-client
+
+// Bitcoin Dev Kit
+// Written in 2020 by Alekos Filini <alekos.filini@gmail.com>
+//
+// Copyright (c) 2020-2021 Bitcoin Dev Kit Developers
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! Esplora by way of `reqwest` HTTP client.
+
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use bitcoin::consensus::{deserialize, serialize};
+use bitcoin::hashes::hex::{FromHex, ToHex};
+use bitcoin::{BlockHash, BlockHeader, Transaction, Txid};
+use reqwest::{Client, StatusCode};
+
+use crate::esplora_client_api::{Error, MerkleProof, OutputStatus, TxStatus};
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct EsploraClient {
+    url: String,
+    client: Client,
+}
+
+#[allow(dead_code)]
+impl EsploraClient {
+    /// build an async client from the base url and [`Client`]
+    pub fn new(url: &str) -> Self {
+        let client = Client::new();
+        EsploraClient {
+            url: url.to_string(),
+            client,
+        }
+    }
+
+    /// Get a [`Transaction`] option given its [`Txid`]
+    pub async fn get_tx(&self, txid: &Txid) -> Result<Option<Transaction>, Error> {
+        let resp = self
+            .client
+            .get(&format!("{}/tx/{}/raw", self.url, txid))
+            .send()
+            .await?;
+
+        if let StatusCode::NOT_FOUND = resp.status() {
+            return Ok(None);
+        }
+
+        Ok(Some(deserialize(&resp.error_for_status()?.bytes().await?)?))
+    }
+
+    /// Get the status of a [`Transaction`] given its [`Txid`].
+    pub async fn get_tx_status(&self, txid: &Txid) -> Result<Option<TxStatus>, Error> {
+        let resp = self
+            .client
+            .get(&format!("{}/tx/{}/status", self.url, txid))
+            .send()
+            .await?;
+
+        if let StatusCode::NOT_FOUND = resp.status() {
+            return Ok(None);
+        }
+
+        Ok(Some(resp.error_for_status()?.json().await?))
+    }
+
+    /// Get a [`BlockHeader`] given a particular block height.
+    pub async fn get_header(&self, block_height: u32) -> Result<BlockHeader, Error> {
+        let resp = self
+            .client
+            .get(&format!("{}/block-height/{}", self.url, block_height))
+            .send()
+            .await?;
+
+        if let StatusCode::NOT_FOUND = resp.status() {
+            return Err(Error::HeaderHeightNotFound(block_height));
+        }
+        let bytes = resp.bytes().await?;
+        let hash =
+            std::str::from_utf8(&bytes).map_err(|_| Error::HeaderHeightNotFound(block_height))?;
+
+        let resp = self
+            .client
+            .get(&format!("{}/block/{}/header", self.url, hash))
+            .send()
+            .await?;
+
+        let header = deserialize(&Vec::from_hex(&resp.text().await?)?)?;
+
+        Ok(header)
+    }
+
+    /// Get a merkle inclusion proof for a [`Transaction`] with the given [`Txid`].
+    pub async fn get_merkle_proof(&self, tx_hash: &Txid) -> Result<Option<MerkleProof>, Error> {
+        let resp = self
+            .client
+            .get(&format!("{}/tx/{}/merkle-proof", self.url, tx_hash))
+            .send()
+            .await?;
+
+        if let StatusCode::NOT_FOUND = resp.status() {
+            return Ok(None);
+        }
+
+        Ok(Some(resp.error_for_status()?.json().await?))
+    }
+
+    /// Get the spending status of an output given a [`Txid`] and the output index.
+    pub async fn get_output_status(
+        &self,
+        txid: &Txid,
+        index: u64,
+    ) -> Result<Option<OutputStatus>, Error> {
+        let resp = self
+            .client
+            .get(&format!("{}/tx/{}/outspend/{}", self.url, txid, index))
+            .send()
+            .await?;
+
+        if let StatusCode::NOT_FOUND = resp.status() {
+            return Ok(None);
+        }
+
+        Ok(Some(resp.error_for_status()?.json().await?))
+    }
+
+    /// Broadcast a [`Transaction`] to Esplora
+    pub async fn broadcast(&self, transaction: &Transaction) -> Result<(), Error> {
+        self.client
+            .post(&format!("{}/tx", self.url))
+            .body(serialize(transaction).to_hex())
+            .send()
+            .await?
+            .error_for_status()?;
+
+        Ok(())
+    }
+
+    /// Get the current height of the blockchain tip
+    pub async fn get_height(&self) -> Result<u32, Error> {
+        let req = self
+            .client
+            .get(&format!("{}/blocks/tip/height", self.url))
+            .send()
+            .await?;
+
+        Ok(req.error_for_status()?.text().await?.parse()?)
+    }
+
+    /// Get the [`BlockHash`] of a specific block height
+    pub async fn get_block_hash(&self, height: u32) -> Result<BlockHash, Error> {
+        let resp = self
+            .client
+            .get(&format!("{}/block-height/{}", self.url, height))
+            .send()
+            .await?;
+
+        Ok(BlockHash::from_str(
+            &resp.error_for_status()?.text().await?,
+        )?)
+    }
+
+    /// Get an map where the key is the confirmation target (in number of blocks)
+    /// and the value is the estimated feerate (in sat/vB).
+    pub async fn get_fee_estimates(&self) -> Result<HashMap<String, f64>, Error> {
+        Ok(self
+            .client
+            .get(&format!("{}/fee-estimates", self.url,))
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<HashMap<String, f64>>()
+            .await?)
+    }
+}

--- a/src/esplora_client_api.rs
+++ b/src/esplora_client_api.rs
@@ -1,0 +1,134 @@
+// This file is for the most part a copy from here:
+// https://github.com/bitcoindevkit/rust-esplora-client/blob/master/src/api.rs
+//
+// Once the functionality has been merged into BDK, we should import the functionality from there,
+// respectively use the rust-esplora-client: https://github.com/bitcoindevkit/rust-esplora-client
+
+//! structs from the esplora API
+//!
+//! see: <https://github.com/Blockstream/esplora/blob/master/API.md>
+
+use bitcoin::hashes::hex::FromHex;
+use bitcoin::{BlockHash, Script, Txid};
+use std::{fmt, io};
+
+use serde::Deserialize;
+
+#[derive(Deserialize, Clone, Debug, PartialEq)]
+pub struct PrevOut {
+    pub value: u64,
+    pub scriptpubkey: Script,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq)]
+pub struct Vin {
+    pub txid: Txid,
+    pub vout: u32,
+    // None if coinbase
+    pub prevout: Option<PrevOut>,
+    pub scriptsig: Script,
+    #[serde(deserialize_with = "deserialize_witness", default)]
+    pub witness: Vec<Vec<u8>>,
+    pub sequence: u32,
+    pub is_coinbase: bool,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq)]
+pub struct Vout {
+    pub value: u64,
+    pub scriptpubkey: Script,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq)]
+pub struct TxStatus {
+    pub confirmed: bool,
+    pub block_height: Option<u32>,
+    pub block_hash: Option<BlockHash>,
+    pub block_time: Option<u64>,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq)]
+pub struct MerkleProof {
+    pub block_height: u32,
+    pub merkle: Vec<Txid>,
+    pub pos: usize,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq)]
+pub struct OutputStatus {
+    pub spent: bool,
+    pub txid: Option<Txid>,
+    pub vin: Option<u64>,
+    pub status: Option<TxStatus>,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct Tx {
+    pub txid: Txid,
+    pub version: i32,
+    pub locktime: u32,
+    pub vin: Vec<Vin>,
+    pub vout: Vec<Vout>,
+    pub status: TxStatus,
+    pub fee: u64,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct BlockTime {
+    pub timestamp: u64,
+    pub height: u32,
+}
+
+fn deserialize_witness<'de, D>(d: D) -> Result<Vec<Vec<u8>>, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    let list = Vec::<String>::deserialize(d)?;
+    list.into_iter()
+        .map(|hex_str| Vec::<u8>::from_hex(&hex_str))
+        .collect::<Result<Vec<Vec<u8>>, _>>()
+        .map_err(serde::de::Error::custom)
+}
+
+/// Errors that can happen during a sync with `Esplora`
+#[derive(Debug)]
+pub enum Error {
+    /// Error during reqwest HTTP request
+    Reqwest(::reqwest::Error),
+    /// IO error during ureq response read
+    Io(io::Error),
+    /// Invalid number returned
+    Parsing(std::num::ParseIntError),
+    /// Invalid Bitcoin data returned
+    BitcoinEncoding(bitcoin::consensus::encode::Error),
+    /// Invalid Hex data returned
+    Hex(bitcoin::hashes::hex::Error),
+    /// Header height not found
+    HeaderHeightNotFound(u32),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+macro_rules! impl_error {
+    ( $from:ty, $to:ident ) => {
+        impl_error!($from, $to, Error);
+    };
+    ( $from:ty, $to:ident, $impl_for:ty ) => {
+        impl std::convert::From<$from> for $impl_for {
+            fn from(err: $from) -> Self {
+                <$impl_for>::$to(err)
+            }
+        }
+    };
+}
+
+impl std::error::Error for Error {}
+impl_error!(::reqwest::Error, Reqwest, Error);
+impl_error!(io::Error, Io, Error);
+impl_error!(std::num::ParseIntError, Parsing, Error);
+impl_error!(bitcoin::consensus::encode::Error, BitcoinEncoding, Error);
+impl_error!(bitcoin::hashes::hex::Error, Hex, Error);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ pub mod keys_manager;
 pub mod secret;
 
 mod async_runtime;
+mod esplora_client;
+mod esplora_client_api;
 mod event_handler;
 mod logger;
 mod native_logger;


### PR DESCRIPTION
This adds an Esplora client to the project, which is however not being used yet by the library. That's why it declares `#[allow(dead_code)]`, which should be undone later, once the client is actually being used.

The client contains all the functionality required for keeping the chain synced for LDK. Not more not less. There is more functionality to be found in the linked source file, linked to in the top of the files `src/esplora_client.rs` and `src/esplora_client_api.rs`

Even though this PR introduces detached code, that is never being called, I still wanted to bring this code into discussion early, because there are a lot of design decisions that should be considered:

- Copied code: Should we rather rely on forks of forks of forks or copy the code and have our own implementation? Should we switch to use maintained libraries later, when the code has eventually been merged?
- Given the nature of copied code that might be replaced by using libraries later .. should we provide any testing?
- Is it okay to go for an `async` client or should we rather develop a `sync` client?