### PR TITLE
Fix Clippy warnings

### DIFF
--- a/examples/node/main.rs
+++ b/examples/node/main.rs
@@ -4,7 +4,6 @@ use file_storage::FileStorage;
 
 use bitcoin::Network;
 use log::info;
-use simplelog;
 use std::fs;
 use uniffi_lipalightninglib::callbacks::RedundantStorageCallback;
 use uniffi_lipalightninglib::config::Config;

--- a/src/async_runtime.rs
+++ b/src/async_runtime.rs
@@ -10,6 +10,7 @@ pub struct AsyncRuntime {
     rt: Runtime,
 }
 
+#[allow(dead_code)]
 impl AsyncRuntime {
     pub fn new() -> Result<Self, InitializationError> {
         let rt = Builder::new_multi_thread()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,10 +26,12 @@ use bitcoin::Network;
 use lightning::util::config::UserConfig;
 use log::{info, warn, Level as LogLevel};
 
+#[allow(dead_code)]
 pub struct LightningNode {
     rt: AsyncRuntime,
 }
 
+#[allow(clippy::let_unit_value)]
 impl LightningNode {
     pub fn new(
         config: Config,


### PR DESCRIPTION
Due to our clippy check CI not working as intended, some clippy warnings are now being thrown on develop.

This PR removes them, by mostly making the clippy rules less strict, which must be undone as soon as the different yet-to-be-developed parts of the project are finally integrated!