### PR TITLE
Fail CI on clippy warnings

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -43,7 +43,7 @@ jobs:
           toolchain: stable
           components: clippy
       - name: Clippy
-        run: cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
   unused_dependencies:
     name: Look for unused dependencies
     runs-on: ubuntu-latest

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -43,7 +43,7 @@ jobs:
           toolchain: stable
           components: clippy
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy -- -D warnings
   unused_dependencies:
     name: Look for unused dependencies
     runs-on: ubuntu-latest

--- a/src/async_runtime.rs
+++ b/src/async_runtime.rs
@@ -7,6 +7,7 @@ use tokio::task::JoinHandle;
 use tokio::time;
 
 pub struct AsyncRuntime {
+    #[allow(dead_code)]
     rt: Runtime,
 }
 
@@ -23,6 +24,7 @@ impl AsyncRuntime {
         Ok(Self { rt })
     }
 
+    #[allow(dead_code)]
     pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
     where
         F: Future + Send + 'static,
@@ -31,6 +33,7 @@ impl AsyncRuntime {
         self.rt.spawn(future)
     }
 
+    #[allow(dead_code)]
     pub fn spawn_repeating_task<Func, F>(&self, interval: Duration, func: Func) -> JoinHandle<()>
     where
         Func: Fn() -> F + Send + Sync + 'static,
@@ -47,6 +50,7 @@ impl AsyncRuntime {
         })
     }
 
+    #[allow(dead_code)]
     pub fn block_on<F: Future>(&self, future: F) -> F::Output
     where
         F: Future + Send + 'static,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::let_unit_value)]
+
 extern crate core;
 
 pub mod callbacks;
@@ -27,6 +29,7 @@ use lightning::util::config::UserConfig;
 use log::{info, warn, Level as LogLevel};
 
 pub struct LightningNode {
+    #[allow(dead_code)]
     rt: AsyncRuntime,
 }
 


### PR DESCRIPTION
Configures Clippy CI job to fail if there are any warnings and fixes warnings. Warnings were fixed by ignoring certain Clippy rules because of the current software being a WIP.