### PR TITLE
Implement outgoing P2P connection to LSP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ name = "uniffi_lipalightninglib"
 [dependencies]
 bdk = { version = "0.22.0", features = ["keys-bip39"] }
 bitcoin = "0.28.1"
+futures = "0.3.24"
 lightning = { version = "0.0.110", features = ["max_level_trace"] }
 lightning-background-processor = "0.0.110"
 lightning-net-tokio = "0.0.110"

--- a/examples/node/main.rs
+++ b/examples/node/main.rs
@@ -3,7 +3,6 @@ mod file_storage;
 use file_storage::FileStorage;
 
 use bitcoin::Network;
-use dotenv::dotenv;
 use log::info;
 use std::env;
 use std::fs;

--- a/examples/node/main.rs
+++ b/examples/node/main.rs
@@ -16,15 +16,6 @@ static BASE_DIR: &str = ".ldk";
 fn main() {
     dotenv::from_path("examples/node/.env").ok();
 
-    println!(
-        "LSP_NODE_PUB_KEY: {}",
-        env::var("LSP_NODE_PUB_KEY").unwrap()
-    );
-    println!(
-        "LSP_NODE_ADDRESS: {}",
-        env::var("LSP_NODE_ADDRESS").unwrap()
-    );
-
     // Create dir for node data persistence.
     fs::create_dir_all(BASE_DIR).unwrap();
 
@@ -38,7 +29,13 @@ fn main() {
         seed,
         esplora_api_url: "http://localhost:30000".to_string(),
     };
-    let _node = LightningNode::new(config, storage).unwrap();
+    let node = LightningNode::new(config, storage).unwrap();
+
+    node.connect_to_peer(
+        env::var("LSP_NODE_PUB_KEY").unwrap(),
+        env::var("LSP_NODE_ADDRESS").unwrap(),
+    )
+    .unwrap();
 }
 
 fn init_logger() {

--- a/src/chain_access.rs
+++ b/src/chain_access.rs
@@ -5,7 +5,7 @@ use lightning::chain::{Confirm, Filter, WatchedOutput};
 use std::sync::{Arc, Mutex};
 
 #[allow(dead_code)]
-pub(crate) struct LipaChainAccess {
+pub struct LipaChainAccess {
     esplora_client: Arc<BlockingClient>,
     queued_txs: Mutex<Vec<(Txid, Script)>>,
     watched_txs: Mutex<Vec<(Txid, Script)>>,

--- a/src/chain_access.rs
+++ b/src/chain_access.rs
@@ -1,4 +1,4 @@
-use crate::errors::ChainSyncError;
+use crate::errors::RuntimeError;
 use bitcoin::{Script, Transaction, Txid};
 use esplora_client::blocking::BlockingClient;
 use lightning::chain::{Confirm, Filter, WatchedOutput};
@@ -32,7 +32,7 @@ impl LipaChainAccess {
     pub(crate) fn sync(
         &self,
         _confirmables: Vec<&(dyn Confirm + Sync)>,
-    ) -> Result<(), ChainSyncError> {
+    ) -> Result<(), RuntimeError> {
         // TODO: sync with the chain
         // this will include moving queued txs and outputs to watched ones
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,6 +23,17 @@ pub enum InitializationError {
 }
 
 #[allow(dead_code)]
-pub(crate) enum ChainSyncError {
-    Other,
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeError {
+    #[error("Failed to synchronize the blockchain: {message}")]
+    ChainSync { message: String },
+
+    #[error("Address could not be parsed: {message}")]
+    InvalidAddress { message: String },
+
+    #[error("Pub key could not be parsed: {message}")]
+    InvalidPubKey { message: String },
+
+    #[error("Could not connect to peer: {message}")]
+    PeerConnection { message: String },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use crate::async_runtime::AsyncRuntime;
 use crate::callbacks::RedundantStorageCallback;
 use crate::chain_access::LipaChainAccess;
 use crate::config::Config;
-use crate::errors::InitializationError;
+use crate::errors::{InitializationError, RuntimeError};
 use crate::event_handler::LipaEventHandler;
 use crate::fee_estimator::FeeEstimator;
 use crate::keys_manager::{generate_random_bytes, generate_secret, init_keys_manager};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub struct LightningNode {
     rt: AsyncRuntime,
     esplora_client: Arc<EsploraClient>,
     background_processor: BackgroundProcessor,
+    peer_manager: Arc<PeerManager>,
 }
 
 type ChainMonitor = LdkChainMonitor<
@@ -229,7 +230,7 @@ impl LightningNode {
             chain_monitor,
             channel_manager,
             GossipSync::rapid(rapid_gossip),
-            peer_manager,
+            Arc::clone(&peer_manager),
             logger,
             Some(scorer),
         );
@@ -238,6 +239,7 @@ impl LightningNode {
             rt,
             esplora_client,
             background_processor,
+            peer_manager,
         })
     }
 }

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -41,6 +41,8 @@ enum RuntimeError {
 interface LightningNode {
     [Throws=InitializationError]
     constructor(Config config, RedundantStorageCallback redundant_storage_callback);
+    [Throws=RuntimeError]
+    void connect_to_peer(string public_key, string address);
 };
 
 enum LogLevel {

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -30,6 +30,14 @@ enum InitializationError {
     "SecretGeneration",
 };
 
+[Error]
+enum RuntimeError {
+    "ChainSync",
+    "InvalidAddress",
+    "InvalidPubKey",
+    "PeerConnection",
+};
+
 interface LightningNode {
     [Throws=InitializationError]
     constructor(Config config, RedundantStorageCallback redundant_storage_callback);

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,7 +1,7 @@
 use lightning::util::logger::{Level, Logger, Record};
 use log::{log, log_enabled};
 
-pub(crate) struct LightningLogger;
+pub struct LightningLogger;
 
 impl Logger for LightningLogger {
     fn log(&self, record: &Record) {

--- a/src/p2p_networking.rs
+++ b/src/p2p_networking.rs
@@ -1,0 +1,49 @@
+use crate::errors::RuntimeError;
+use crate::{AsyncRuntime, PeerManager};
+use bitcoin::secp256k1::PublicKey;
+use log::debug;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+pub fn connect_to_peer(
+    rt: &AsyncRuntime,
+    peer_manager: Arc<PeerManager>,
+    pubkey: PublicKey,
+    addr: SocketAddr,
+) -> Result<(), RuntimeError> {
+    rt.handle().block_on(async move {
+        let result =
+            lightning_net_tokio::connect_outbound(Arc::clone(&peer_manager), pubkey, addr).await;
+
+        if let Some(connection_closed_future) = result {
+            let mut connection_closed_future = Box::pin(connection_closed_future);
+            loop {
+                // Make sure the connection is still established.
+                match futures::poll!(&mut connection_closed_future) {
+                    std::task::Poll::Ready(_) => {
+                        return Err(RuntimeError::PeerConnection {
+                            message: "Peer disconnected before handshake completed".to_string(),
+                        });
+                    }
+                    std::task::Poll::Pending => {
+                        debug!("Peer connection to {} still pending", pubkey);
+                    }
+                }
+
+                // Wait for the handshake to complete.
+                match peer_manager
+                    .get_peer_node_ids()
+                    .iter()
+                    .find(|id| **id == pubkey)
+                {
+                    Some(_) => return Ok(()),
+                    None => tokio::time::sleep(std::time::Duration::from_millis(10)).await,
+                }
+            }
+        }
+
+        Err(RuntimeError::PeerConnection {
+            message: format!("Failed to connect to peer {}", pubkey),
+        })
+    })
+}

--- a/src/tx_broadcaster.rs
+++ b/src/tx_broadcaster.rs
@@ -4,7 +4,7 @@ use lightning::chain::chaininterface::BroadcasterInterface;
 use log::error;
 use std::sync::Arc;
 
-pub(crate) struct TxBroadcaster {
+pub struct TxBroadcaster {
     esplora_client: Arc<BlockingClient>,
 }
 


### PR DESCRIPTION
Open a connection to another Lightning node (LSP) over the LN P2P.

This is necessary, because we don't listen to incoming connections, so the only way to connect with the LSP is an out-going connection.