### PR TITLE
Implement outgoing P2P connection to LSP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ name = "uniffi_lipalightninglib"
 [dependencies]
 bdk = { version = "0.22.0", features = ["keys-bip39"] }
 bitcoin = "0.28.1"
+futures = "0.3.24"
 lightning = { version = "0.0.110", features = ["max_level_trace"] }
 lightning-background-processor = "0.0.110"
 lightning-net-tokio = "0.0.110"

--- a/examples/node/main.rs
+++ b/examples/node/main.rs
@@ -7,7 +7,7 @@ use log::info;
 use std::env;
 use std::fs;
 use uniffi_lipalightninglib::callbacks::RedundantStorageCallback;
-use uniffi_lipalightninglib::config::{Config, LspConfig};
+use uniffi_lipalightninglib::config::{Config, NodeAddress};
 use uniffi_lipalightninglib::keys_manager::generate_secret;
 use uniffi_lipalightninglib::LightningNode;
 
@@ -28,7 +28,7 @@ fn main() {
         network: Network::Regtest,
         seed,
         esplora_api_url: "http://localhost:30000".to_string(),
-        lsp: LspConfig {
+        lsp_node: NodeAddress {
             pub_key: env::var("LSP_NODE_PUB_KEY").unwrap(),
             address: env::var("LSP_NODE_ADDRESS").unwrap(),
         },
@@ -36,7 +36,7 @@ fn main() {
 
     let node = LightningNode::new(&config, storage).unwrap();
 
-    node.connect_to_peer(&config.lsp).unwrap();
+    node.connect_to_peer(&config.lsp_node).unwrap();
 }
 
 fn init_logger() {

--- a/examples/node/main.rs
+++ b/examples/node/main.rs
@@ -34,9 +34,7 @@ fn main() {
         },
     };
 
-    let node = LightningNode::new(&config, storage).unwrap();
-
-    node.connect_to_peer(&config.lsp_node).unwrap();
+    let _node = LightningNode::new(&config, storage).unwrap();
 }
 
 fn init_logger() {

--- a/examples/node/main.rs
+++ b/examples/node/main.rs
@@ -7,7 +7,7 @@ use log::info;
 use std::env;
 use std::fs;
 use uniffi_lipalightninglib::callbacks::RedundantStorageCallback;
-use uniffi_lipalightninglib::config::Config;
+use uniffi_lipalightninglib::config::{Config, LspConfig};
 use uniffi_lipalightninglib::keys_manager::generate_secret;
 use uniffi_lipalightninglib::LightningNode;
 
@@ -28,14 +28,15 @@ fn main() {
         network: Network::Regtest,
         seed,
         esplora_api_url: "http://localhost:30000".to_string(),
+        lsp: LspConfig {
+            pub_key: env::var("LSP_NODE_PUB_KEY").unwrap(),
+            address: env::var("LSP_NODE_ADDRESS").unwrap(),
+        },
     };
-    let node = LightningNode::new(config, storage).unwrap();
 
-    node.connect_to_peer(
-        env::var("LSP_NODE_PUB_KEY").unwrap(),
-        env::var("LSP_NODE_ADDRESS").unwrap(),
-    )
-    .unwrap();
+    let node = LightningNode::new(&config, storage).unwrap();
+
+    node.connect_to_peer(&config.lsp).unwrap();
 }
 
 fn init_logger() {

--- a/examples/node/main.rs
+++ b/examples/node/main.rs
@@ -16,15 +16,6 @@ static BASE_DIR: &str = ".ldk";
 fn main() {
     dotenv::from_path("examples/node/.env").ok();
 
-    println!(
-        "LSP_NODE_PUB_KEY: {}",
-        env::var("LSP_NODE_PUB_KEY").unwrap()
-    );
-    println!(
-        "LSP_NODE_ADDRESS: {}",
-        env::var("LSP_NODE_ADDRESS").unwrap()
-    );
-
     // Create dir for node data persistence.
     fs::create_dir_all(BASE_DIR).unwrap();
 
@@ -38,7 +29,13 @@ fn main() {
         seed,
         esplora_api_url: "http://localhost:30000".to_string(),
     };
-    let _node = LightningNode::new(config, storage).unwrap();
+    let node = LightningNode::new(config, storage).unwrap();
+
+    node.connect_to_peer(
+        env::var("LSP_NODE_PUB_KEY").unwrap(),
+        env::var("LSP_NODE_ADDRESS").unwrap(),
+    )
+    .unwrap();
 }
 
 fn init_logger() {

--- a/src/chain_access.rs
+++ b/src/chain_access.rs
@@ -5,7 +5,7 @@ use lightning::chain::{Confirm, Filter, WatchedOutput};
 use std::sync::{Arc, Mutex};
 
 #[allow(dead_code)]
-pub(crate) struct LipaChainAccess {
+pub struct LipaChainAccess {
     esplora_client: Arc<BlockingClient>,
     queued_txs: Mutex<Vec<(Txid, Script)>>,
     watched_txs: Mutex<Vec<(Txid, Script)>>,

--- a/src/chain_access.rs
+++ b/src/chain_access.rs
@@ -5,7 +5,7 @@ use lightning::chain::{Confirm, Filter, WatchedOutput};
 use std::sync::{Arc, Mutex};
 
 #[allow(dead_code)]
-pub struct LipaChainAccess {
+pub(crate) struct LipaChainAccess {
     esplora_client: Arc<BlockingClient>,
     queued_txs: Mutex<Vec<(Txid, Script)>>,
     watched_txs: Mutex<Vec<(Txid, Script)>>,

--- a/src/chain_access.rs
+++ b/src/chain_access.rs
@@ -1,4 +1,4 @@
-use crate::errors::ChainSyncError;
+use crate::errors::RuntimeError;
 use bitcoin::{Script, Transaction, Txid};
 use esplora_client::blocking::BlockingClient;
 use lightning::chain::{Confirm, Filter, WatchedOutput};
@@ -32,7 +32,7 @@ impl LipaChainAccess {
     pub(crate) fn sync(
         &self,
         _confirmables: Vec<&(dyn Confirm + Sync)>,
-    ) -> Result<(), ChainSyncError> {
+    ) -> Result<(), RuntimeError> {
         // TODO: sync with the chain
         // this will include moving queued txs and outputs to watched ones
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,4 +11,10 @@ pub struct Config {
     pub network: Network,
     pub seed: Vec<u8>,
     pub esplora_api_url: String,
+    pub lsp: LspConfig,
+}
+
+pub struct LspConfig {
+    pub pub_key: String,
+    pub address: String,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,10 +11,10 @@ pub struct Config {
     pub network: Network,
     pub seed: Vec<u8>,
     pub esplora_api_url: String,
-    pub lsp: LspConfig,
+    pub lsp_node: NodeAddress,
 }
 
-pub struct LspConfig {
+pub struct NodeAddress {
     pub pub_key: String,
     pub address: String,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,6 +18,9 @@ pub enum InitializationError {
     #[error("Logic error: {message}")]
     Logic { message: String },
 
+    #[error("Could not connect to peer: {message}")]
+    PeerConnection { message: String },
+
     #[error("Failed to generate random entropy: {message}")]
     SecretGeneration { message: String },
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,6 +23,17 @@ pub enum InitializationError {
 }
 
 #[allow(dead_code)]
-pub(crate) enum ChainSyncError {
-    Other,
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeError {
+    #[error("Failed to synchronize the blockchain: {message}")]
+    ChainSync { message: String },
+
+    #[error("Address could not be parsed: {message}")]
+    InvalidAddress { message: String },
+
+    #[error("Pub key could not be parsed: {message}")]
+    InvalidPubKey { message: String },
+
+    #[error("Could not connect to peer: {message}")]
+    PeerConnection { message: String },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ mod tx_broadcaster;
 use crate::async_runtime::AsyncRuntime;
 use crate::callbacks::RedundantStorageCallback;
 use crate::chain_access::LipaChainAccess;
-use crate::config::{Config, LspConfig};
+use crate::config::{Config, NodeAddress};
 use crate::errors::{InitializationError, RuntimeError};
 use crate::event_handler::LipaEventHandler;
 use crate::fee_estimator::FeeEstimator;
@@ -248,7 +248,7 @@ impl LightningNode {
         })
     }
 
-    pub fn connect_to_peer(&self, lsp_config: &LspConfig) -> Result<(), RuntimeError> {
+    pub fn connect_to_peer(&self, lsp_config: &NodeAddress) -> Result<(), RuntimeError> {
         let pubkey =
             PublicKey::from_str(&lsp_config.pub_key).map_err(|e| RuntimeError::InvalidPubKey {
                 message: e.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use crate::async_runtime::AsyncRuntime;
 use crate::callbacks::RedundantStorageCallback;
 use crate::chain_access::LipaChainAccess;
 use crate::config::Config;
-use crate::errors::InitializationError;
+use crate::errors::{InitializationError, RuntimeError};
 use crate::event_handler::LipaEventHandler;
 use crate::fee_estimator::FeeEstimator;
 use crate::keys_manager::{generate_random_bytes, generate_secret, init_keys_manager};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ pub struct LightningNode {
     rt: AsyncRuntime,
     esplora_client: Arc<EsploraClient>,
     background_processor: BackgroundProcessor,
+    peer_manager: Arc<PeerManager>,
 }
 
 type ChainMonitor = LdkChainMonitor<
@@ -230,7 +231,7 @@ impl LightningNode {
             chain_monitor,
             channel_manager,
             GossipSync::rapid(rapid_gossip),
-            peer_manager,
+            Arc::clone(&peer_manager),
             logger,
             Some(scorer),
         );
@@ -239,6 +240,7 @@ impl LightningNode {
             rt,
             esplora_client,
             background_processor,
+            peer_manager,
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ mod tx_broadcaster;
 use crate::async_runtime::AsyncRuntime;
 use crate::callbacks::RedundantStorageCallback;
 use crate::chain_access::LipaChainAccess;
-use crate::config::Config;
+use crate::config::{Config, LspConfig};
 use crate::errors::{InitializationError, RuntimeError};
 use crate::event_handler::LipaEventHandler;
 use crate::fee_estimator::FeeEstimator;
@@ -87,7 +87,7 @@ pub(crate) type PeerManager = lightning::ln::peer_handler::PeerManager<
 
 impl LightningNode {
     pub fn new(
-        config: Config,
+        config: &Config,
         redundant_storage_callback: Box<dyn RedundantStorageCallback>,
     ) -> Result<Self, InitializationError> {
         let rt = AsyncRuntime::new()?;
@@ -248,13 +248,16 @@ impl LightningNode {
         })
     }
 
-    pub fn connect_to_peer(&self, pubkey: String, addr: String) -> Result<(), RuntimeError> {
-        let pubkey = PublicKey::from_str(&pubkey).map_err(|e| RuntimeError::InvalidPubKey {
-            message: e.to_string(),
-        })?;
+    pub fn connect_to_peer(&self, lsp_config: &LspConfig) -> Result<(), RuntimeError> {
+        let pubkey =
+            PublicKey::from_str(&lsp_config.pub_key).map_err(|e| RuntimeError::InvalidPubKey {
+                message: e.to_string(),
+            })?;
 
-        let addr = SocketAddr::from_str(&addr).map_err(|e| RuntimeError::InvalidAddress {
-            message: e.to_string(),
+        let addr = SocketAddr::from_str(&lsp_config.address).map_err(|e| {
+            RuntimeError::InvalidAddress {
+                message: e.to_string(),
+            }
         })?;
 
         p2p_networking::connect_to_peer(&self.rt, Arc::clone(&self.peer_manager), pubkey, addr)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod callbacks;
 pub mod config;
 pub mod errors;
 pub mod keys_manager;
+pub mod p2p_networking;
 pub mod secret;
 
 mod async_runtime;
@@ -30,8 +31,10 @@ use crate::native_logger::init_native_logger_once;
 use crate::secret::Secret;
 use crate::storage_persister::StoragePersister;
 use crate::tx_broadcaster::TxBroadcaster;
+use std::net::SocketAddr;
 
 use bitcoin::blockdata::constants::genesis_block;
+use bitcoin::secp256k1::PublicKey;
 use bitcoin::Network;
 use esplora_client::blocking::BlockingClient as EsploraClient;
 use esplora_client::Builder;
@@ -48,6 +51,7 @@ use lightning_background_processor::{BackgroundProcessor, GossipSync};
 use lightning_net_tokio::SocketDescriptor;
 use lightning_rapid_gossip_sync::RapidGossipSync;
 use log::{warn, Level as LogLevel};
+use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
 static ESPLORA_TIMEOUT_SECS: u64 = 30;
@@ -242,6 +246,18 @@ impl LightningNode {
             background_processor,
             peer_manager,
         })
+    }
+
+    pub fn connect_to_peer(&self, pubkey: String, addr: String) -> Result<(), RuntimeError> {
+        let pubkey = PublicKey::from_str(&pubkey).map_err(|e| RuntimeError::InvalidPubKey {
+            message: e.to_string(),
+        })?;
+
+        let addr = SocketAddr::from_str(&addr).map_err(|e| RuntimeError::InvalidAddress {
+            message: e.to_string(),
+        })?;
+
+        p2p_networking::connect_to_peer(&self.rt, Arc::clone(&self.peer_manager), pubkey, addr)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,9 +200,10 @@ impl LightningNode {
         )?);
 
         // Step 13. Initialize Networking
-        let peer_mgr = Arc::clone(&peer_manager);
+        let peer_manager_clone = Arc::clone(&peer_manager);
+
         rt.handle().block_on(async move {
-            P2pConnections::connect_peer(&config.lsp_node, Arc::clone(&peer_mgr))
+            P2pConnections::connect_peer(&config.lsp_node, Arc::clone(&peer_manager_clone))
                 .await
                 .map_err(|e| InitializationError::PeerConnection {
                     message: e.to_string(),

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -9,10 +9,10 @@ dictionary Config {
     Network network;
     sequence<u8> seed;
     string esplora_api_url;
-    LspConfig lsp;
+    NodeAddress lsp_node;
 };
 
-dictionary LspConfig {
+dictionary NodeAddress {
     string pub_key;
     string address;
 };

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -41,6 +41,8 @@ enum RuntimeError {
 interface LightningNode {
     [Throws=InitializationError]
     constructor(Config config, RedundantStorageCallback redundant_storage_callback);
+    [Throws=RuntimeError]
+    void connect_to_peer(string public_key, string address);
 };
 
 enum LogLevel {

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -33,6 +33,7 @@ enum InitializationError {
     "EsploraClient",
     "KeysManager",
     "Logic",
+    "PeerConnection",
     "SecretGeneration",
 };
 

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -9,6 +9,12 @@ dictionary Config {
     Network network;
     sequence<u8> seed;
     string esplora_api_url;
+    LspConfig lsp;
+};
+
+dictionary LspConfig {
+    string pub_key;
+    string address;
 };
 
 callback interface RedundantStorageCallback {
@@ -40,9 +46,7 @@ enum RuntimeError {
 
 interface LightningNode {
     [Throws=InitializationError]
-    constructor(Config config, RedundantStorageCallback redundant_storage_callback);
-    [Throws=RuntimeError]
-    void connect_to_peer(string public_key, string address);
+    constructor([ByRef] Config config, RedundantStorageCallback redundant_storage_callback);
 };
 
 enum LogLevel {

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -30,6 +30,14 @@ enum InitializationError {
     "SecretGeneration",
 };
 
+[Error]
+enum RuntimeError {
+    "ChainSync",
+    "InvalidAddress",
+    "InvalidPubKey",
+    "PeerConnection",
+};
+
 interface LightningNode {
     [Throws=InitializationError]
     constructor(Config config, RedundantStorageCallback redundant_storage_callback);

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,7 +1,7 @@
 use lightning::util::logger::{Level, Logger, Record};
 use log::{log, log_enabled};
 
-pub(crate) struct LightningLogger;
+pub struct LightningLogger;
 
 impl Logger for LightningLogger {
     fn log(&self, record: &Record) {

--- a/src/p2p_networking.rs
+++ b/src/p2p_networking.rs
@@ -64,8 +64,7 @@ impl P2pConnections {
         peer_manager
             .get_peer_node_ids()
             .iter()
-            .find(|id| *id == &peer.pub_key)
-            .is_some()
+            .any(|id| *id == peer.pub_key)
     }
 }
 

--- a/src/p2p_networking.rs
+++ b/src/p2p_networking.rs
@@ -1,0 +1,49 @@
+use crate::errors::RuntimeError;
+use crate::{AsyncRuntime, PeerManager};
+use bitcoin::secp256k1::PublicKey;
+use log::debug;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+pub fn connect_to_peer(
+    rt: &AsyncRuntime,
+    peer_manager: Arc<PeerManager>,
+    pubkey: PublicKey,
+    addr: SocketAddr,
+) -> Result<(), RuntimeError> {
+    rt.handle().block_on(async move {
+        let result =
+            lightning_net_tokio::connect_outbound(Arc::clone(&peer_manager), pubkey, addr).await;
+
+        if let Some(connection_closed_future) = result {
+            let mut connection_closed_future = Box::pin(connection_closed_future);
+            loop {
+                // Make sure the connection is still established.
+                match futures::poll!(&mut connection_closed_future) {
+                    std::task::Poll::Ready(_) => {
+                        return Err(RuntimeError::PeerConnection {
+                            message: "Peer disconnected before handshake completed".to_string(),
+                        });
+                    }
+                    std::task::Poll::Pending => {
+                        debug!("Peer connection to {} still pending", pubkey);
+                    }
+                }
+
+                // Wait for the handshake to complete.
+                match peer_manager
+                    .get_peer_node_ids()
+                    .iter()
+                    .find(|id| **id == pubkey)
+                {
+                    Some(_) => return Ok(()),
+                    None => tokio::time::sleep(std::time::Duration::from_millis(10)).await,
+                }
+            }
+        }
+
+        Err(RuntimeError::PeerConnection {
+            message: format!("Failed to connect to peer {}", pubkey),
+        })
+    })
+}

--- a/src/tx_broadcaster.rs
+++ b/src/tx_broadcaster.rs
@@ -4,7 +4,7 @@ use lightning::chain::chaininterface::BroadcasterInterface;
 use log::error;
 use std::sync::Arc;
 
-pub(crate) struct TxBroadcaster {
+pub struct TxBroadcaster {
     esplora_client: Arc<BlockingClient>,
 }
 

--- a/src/tx_broadcaster.rs
+++ b/src/tx_broadcaster.rs
@@ -4,7 +4,7 @@ use lightning::chain::chaininterface::BroadcasterInterface;
 use log::error;
 use std::sync::Arc;
 
-pub struct TxBroadcaster {
+pub(crate) struct TxBroadcaster {
     esplora_client: Arc<BlockingClient>,
 }
 


### PR DESCRIPTION
Open a connection to another Lightning node (LSP) over the LN P2P.

This is necessary, because we don't listen to incoming connections, so the only way to connect with the LSP is an outgoing connection.