### PR TITLE
Shutdown node gracefully when LightningNode gets out of scope

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,6 +258,7 @@ impl LightningNode {
 
 impl Drop for LightningNode {
     fn drop(&mut self) {
+        // TODO: Stop reconnecting to peers
         self.peer_manager.disconnect_all_peers();
 
         // The background processor implements the drop trait itself.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,15 @@ impl LightningNode {
     }
 }
 
+impl Drop for LightningNode {
+    fn drop(&mut self) {
+        self.peer_manager.disconnect_all_peers();
+
+        // The background processor implements the drop trait itself.
+        // It therefore doesn't have to be stopped manually.
+    }
+}
+
 #[allow(clippy::field_reassign_with_default)]
 fn build_mobile_node_user_config() -> UserConfig {
     let mut user_config = UserConfig::default();


### PR DESCRIPTION
When the node is being stopped, we want do 2 things for a clean shutdown:
* Disconnect all peers
* Gracefully shutdown the `BackgroundProcessor`

The background processor actually [implements the Drop trait itself](https://github.com/lightningdevkit/rust-lightning/blob/7bc52aa62cb3c32f51b242ad3fa0ae16aee80cec/lightning-background-processor/src/lib.rs#L566). This [stops the thread](https://github.com/lightningdevkit/rust-lightning/blob/7bc52aa62cb3c32f51b242ad3fa0ae16aee80cec/lightning-background-processor/src/lib.rs#L560) in [which the background processor is running](https://github.com/lightningdevkit/rust-lightning/blob/7bc52aa62cb3c32f51b242ad3fa0ae16aee80cec/lightning-background-processor/src/lib.rs#L517) (wrapped inside macro `define_run_body!`). So there's no need to do anything from 3L's side, it can just wait for the `BackgroundProcessor` to go out of scope.

On the contrary, function `peer_manager.disconnect_all_peers()` is never being called. However, when I was running tests locally and I was checking on the connected LND node, the 3L example node was actually anyways being disconnected from LND as soon as the 3L example node stopped running. I couldn't figure out how this disconnecting was initiated, but maybe it was just the LND node that disconnected the peer, once the TCP connection disconnected. 

Anyhow, it feels kind of like the right thing to do to call  `peer_manager.disconnect_all_peers()` when the node shuts down, and there doesn't seem to be any big drawback even if it would turn out that this step was actually not necessary.