### PR TITLE
Panic on missing example node config

### DIFF
--- a/examples/node/main.rs
+++ b/examples/node/main.rs
@@ -14,7 +14,7 @@ use uniffi_lipalightninglib::LightningNode;
 static BASE_DIR: &str = ".ldk";
 
 fn main() {
-    dotenv::from_path("examples/node/.env").ok();
+    dotenv::from_path("examples/node/.env").unwrap();
 
     // Create dir for node data persistence.
     fs::create_dir_all(BASE_DIR).unwrap();


### PR DESCRIPTION
Change behavior of how the example node loads the `.env` file.

**Before:**
Load `.env` if the file is present, otherwise assume that environment variables are set in another way or are not present at all.

**Afterwards:**
Make `.env` file mandatory. Panic if it can't be found.
