### PR TITLE
Run nigiri tests explicitly

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,4 +28,4 @@ jobs:
           echo "RUNNING_ON_CI=true" >> $GITHUB_ENV
       - name: Run integration tests
         run: |
-          cargo test --test '*' -- --test-threads 1 # runs integration tests only and sequentially
+          cargo test --features nigiri_test --test '*' -- --test-threads 1 # runs integration tests only and sequentially

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 crate-type = ["lib", "staticlib", "cdylib"]
 name = "uniffi_lipalightninglib"
 
+[features]
+nigiri_test = []
+
 [dependencies]
 bdk = { version = "0.22.0", features = ["keys-bip39"] }
 bitcoin = "0.28.1"

--- a/tests/p2p_connection_test.rs
+++ b/tests/p2p_connection_test.rs
@@ -2,11 +2,11 @@ mod setup;
 
 use std::env;
 
-// Caution: Run this test sequentially,
-// otherwise they will corrupt eachother, because they're manipulating their environment:
-// cargo test --test '*' -- --test-threads 1
-#[cfg(test)]
-mod p2p_connection_tests {
+// Caution: Run these tests sequentially, otherwise they will corrupt each other,
+// because they are manipulating their environment:
+// cargo test --features nigiri_test -- --test-threads 1
+#[cfg(feature = "nigiri_test")]
+mod p2p_connection_test {
     use super::*;
 
     #[test]


### PR DESCRIPTION
`cargo test` should not manipulate the environment. Now they can be run only explicitly: `cargo test --features nigiri_test`.