### PR TITLE
Update lightning requirements from 0.0.110 to 0.0.111

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ nigiri = []
 [dependencies]
 aes = "0.8.1"
 bdk = { version = "0.23.0", features = ["keys-bip39"] }
-bitcoin = "0.28.1"
+bitcoin = "0.29.1"
 cbc = "0.1.2"
 cipher = { version = "0.4.3", features = ["block-padding", "alloc"] }
 futures = "0.3.24"
-lightning = { version = "0.0.110", features = ["max_level_trace"] }
-lightning-background-processor = "0.0.110"
-lightning-net-tokio = "0.0.110"
-lightning-rapid-gossip-sync = "0.0.110"
+lightning = { version = "0.0.111", features = ["max_level_trace"] }
+lightning-background-processor = "0.0.111"
+lightning-net-tokio = "0.0.111"
+lightning-rapid-gossip-sync = "0.0.111"
 log = "0.4.17"
 rand = "0.8.5"
 thiserror = "1.0.34"

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -1,9 +1,9 @@
 use crate::errors::RuntimeError;
 
 use aes::cipher::{block_padding::Pkcs7, BlockEncryptMut, BlockSizeUser, KeyIvInit};
+use bdk::bitcoin::secp256k1::rand::thread_rng;
+use bdk::bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use bitcoin::hashes::{sha256, sha512, Hash, HashEngine, Hmac, HmacEngine};
-use bitcoin::secp256k1::rand::thread_rng;
-use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use rand::rngs::OsRng;
 use rand::RngCore;
 
@@ -108,7 +108,7 @@ mod test {
     #[test]
     fn test_generate_shared_secret() {
         let secp = Secp256k1::new();
-        let ephemeral = bitcoin::secp256k1::ONE_KEY;
+        let ephemeral = bdk::bitcoin::secp256k1::ONE_KEY;
         let ephemeral_pubkey = PublicKey::from_secret_key(&secp, &ephemeral);
         let privkey =
             Vec::from_hex("6afa9046a9579cad143a384c1b564b9a250d27d6f6a63f9f20bf3a7594c9e2c6")
@@ -169,7 +169,7 @@ mod test {
         // Tested against Decrypt() from btcsuite/btcd
         // https://github.com/btcsuite/btcd/blob/v0.22/btcec/ciphering.go#L121
         let secp = Secp256k1::new();
-        let ephemeral = bitcoin::secp256k1::ONE_KEY;
+        let ephemeral = bdk::bitcoin::secp256k1::ONE_KEY;
         let ephemeral_pubkey = PublicKey::from_secret_key(&secp, &ephemeral);
         let init_vector = Vec::from_hex("6afa9046a9579cad143a384c1b564b9a").unwrap();
         let randomness = Randomness {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,4 +1,4 @@
-use bitcoin::{Script, Transaction, Txid};
+use bitcoin::{Script, Txid};
 use lightning::chain::{Filter, WatchedOutput};
 use std::sync::Mutex;
 
@@ -43,13 +43,8 @@ impl Filter for FilterImpl {
             .push((*txid, script_pubkey.clone()));
     }
 
-    fn register_output(&self, output: WatchedOutput) -> Option<(usize, Transaction)> {
+    fn register_output(&self, output: WatchedOutput) {
         self.data.lock().unwrap().outputs.push(output);
-        // The Filter::register_output return value has been removed, as it was very difficult to
-        // correctly implement (i.e., without blocking). Users previously using it should instead
-        // pass dependent transactions in via additional chain::Confirm::transactions_confirmed
-        // calls (#1663).
-        None
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ use lightning::chain::channelmonitor::ChannelMonitor;
 use lightning::chain::keysinterface::{InMemorySigner, KeysInterface, KeysManager, Recipient};
 use lightning::chain::{BestBlock, Watch};
 use lightning::ln::channelmanager::ChainParameters;
+use lightning::ln::peer_handler::IgnoringMessageHandler;
 use lightning::routing::gossip::NetworkGraph;
 use lightning::routing::scoring::{ProbabilisticScorer, ProbabilisticScoringParameters};
 use lightning::util::config::UserConfig;
@@ -55,6 +56,7 @@ use lightning_background_processor::{BackgroundProcessor, GossipSync};
 use lightning_rapid_gossip_sync::RapidGossipSync;
 use log::{debug, error, warn, Level as LogLevel};
 use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::task::JoinHandle;
 use tokio::time::{Duration, Instant};
 
@@ -333,7 +335,12 @@ fn init_peer_manager(
         })?;
     Ok(PeerManager::new_channel_only(
         channel_manager,
+        IgnoringMessageHandler {},
         our_node_secret,
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
         &ephemeral_bytes,
         logger,
     ))

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,6 +27,7 @@ pub(crate) type PeerManager = lightning::ln::peer_handler::PeerManager<
     SocketDescriptor,
     Arc<ChannelManager>,
     IgnoringMessageHandler,
+    IgnoringMessageHandler,
     Arc<LightningLogger>,
     IgnoringMessageHandler,
 >;


### PR DESCRIPTION
Only a draft because it relies on a fork of the `rust-esplora-client`. Waiting for https://github.com/bitcoindevkit/rust-esplora-client/pull/20.