### PR TITLE
Use new version for Esplora client dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1.0.34"
 tokio = { version = "1.21.1", features = ["rt-multi-thread", "time"] }
 uniffi = "0.21.0"
 
-esplora-client = { git = "https://github.com/bitcoindevkit/rust-esplora-client", branch = "master", default-features = false, features = ["blocking"] }
+esplora-client = { version = "0.2.0" , default-features = false, features = ["blocking"] }
 
 [dev-dependencies]
 bitcoin_hashes = "0.11.0"


### PR DESCRIPTION
Now that a new version of [rust-esplora-client](https://github.com/bitcoindevkit/rust-esplora-client") has been released, which contains all the changes we need, we should switch to working with proper versioning.