### PR TITLE
Add error

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,104 @@
 use uniffi::ffi::foreigncallbacks::UnexpectedUniFFICallbackError;
 
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+pub enum Error {
+    /// Invalid input.
+    /// Consider fixing the input and retrying the request.
+    #[error("InvalidInput: {message}")]
+    InvalidInput { message: String },
+    /// Recoverable problem (e.g. network issue, problem with en external service).
+    /// Consider retrying the request.
+    #[error("RuntimeError: {message}")]
+    RuntimeError { message: String },
+    /// Unrecoverable problem (e.g. internal invariant broken).
+    /// Consider reporting.
+    #[error("PermanentFailure: {message}")]
+    PermanentFailure { message: String },
+}
+
+pub fn invalid_input<T: ToString>(e: T) -> Error {
+    Error::InvalidInput {
+        message: e.to_string(),
+    }
+}
+
+pub fn invalid_input_with<T: ToString>(message: String) -> Box<dyn FnOnce(T) -> Error> {
+    Box::new(move |e: T| Error::InvalidInput {
+        message: format!("{}: {}", message, e.to_string()),
+    })
+}
+
+pub fn runtime_error<T: ToString>(e: T) -> Error {
+    Error::RuntimeError {
+        message: e.to_string(),
+    }
+}
+
+pub fn runtime_error_with<T: ToString>(message: String) -> Box<dyn FnOnce(T) -> Error> {
+    Box::new(move |e: T| Error::RuntimeError {
+        message: format!("{}: {}", message, e.to_string()),
+    })
+}
+
+pub fn permanent_failure<T: ToString>(e: T) -> Error {
+    Error::PermanentFailure {
+        message: e.to_string(),
+    }
+}
+
+pub fn permanent_failure_with<T: ToString>(message: String) -> Box<dyn FnOnce(T) -> Error> {
+    Box::new(move |e: T| Error::PermanentFailure {
+        message: format!("{}: {}", message, e.to_string()),
+    })
+}
+
+pub fn lift_invalid_input(e: Error) -> Error {
+    match e {
+        Error::InvalidInput { message } => Error::PermanentFailure {
+            message: "InvalidInput: ".to_string() + &message,
+        },
+        another_error => another_error,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_map_err() {
+        use std::io::{Error, ErrorKind, Result};
+        let io_error: Result<()> = Err(Error::new(ErrorKind::Other, "File not found"));
+        let our_error = io_error.map_err(runtime_error).unwrap_err();
+        assert_eq!(our_error.to_string(), "RuntimeError: File not found");
+
+        let io_error: Result<()> = Err(Error::new(ErrorKind::Other, "File not found"));
+        let our_error = io_error
+            .map_err(runtime_error_with("No backup".to_string()))
+            .unwrap_err();
+        assert_eq!(
+            our_error.to_string(),
+            "RuntimeError: No backup: File not found"
+        );
+    }
+
+    #[test]
+    fn test_lift_invalid_input() {
+        assert_eq!(
+            lift_invalid_input(invalid_input("Number must be positive")),
+            permanent_failure("InvalidInput: Number must be positive")
+        );
+        assert_eq!(
+            lift_invalid_input(runtime_error("Socket timeout")),
+            runtime_error("Socket timeout")
+        );
+        assert_eq!(
+            lift_invalid_input(permanent_failure("Devision by zero")),
+            permanent_failure("Devision by zero")
+        );
+    }
+}
+
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, thiserror::Error)]
 pub enum InitializationError {


### PR DESCRIPTION
I find our error model very detailed, but useless. It precisely says what has happened, but does not give any clue how to react on it. I suggest we introduce only one generic `Error` enum and use it where we want to return an error in internal or external code.
Some functions will help us convert io/LDK error into our types like:
```rust
fn foo() -> Result<(), Error> {
    // Result into -> InvalidInput: <message from parse()>
    let request = parse().map_err(invalid_input)?;

    // Result into -> RuntimeError: Email client error: <message from call()>
    let response = email_client.call(request).map_err(runtime_error_with("Email client error")?;

    // If InvalidInput, result into -> PermanentFailure: InvalidInput: <message from our_internal_function()>
    // else -> <message from our_internal_function()>
    our_internal_function(response).map_err(lift_invalid_input)?
}

