### PR TITLE
Integration test: Multiple txs at the same time

### DIFF
--- a/src/chain_access.rs
+++ b/src/chain_access.rs
@@ -81,9 +81,7 @@ impl LipaChainAccess {
 
             match self.filter.drain() {
                 Some(filter_data) => {
-                    filter_data.txs.iter().for_each(|tx| {
-                        self.watched_txs.insert((tx.0, tx.1.clone()));
-                    });
+                    self.watched_txs.extend(filter_data.txs.into_iter());
                     self.watched_outputs.extend(filter_data.outputs.into_iter())
                 }
                 None => break,

--- a/tests/chain_sync_test.rs
+++ b/tests/chain_sync_test.rs
@@ -145,7 +145,7 @@ mod chain_sync_test {
 
     fn setup() -> NodeHandle {
         nigiri::start();
-        let lsp_info = setup::nigiri::query_lnd_info().unwrap();
+        let lsp_info = nigiri::query_lnd_info().unwrap();
         let lsp_node = NodeAddress {
             pub_key: lsp_info.pub_key,
             address: "127.0.0.1:9735".to_string(),

--- a/tests/chain_sync_test.rs
+++ b/tests/chain_sync_test.rs
@@ -153,7 +153,10 @@ mod chain_sync_test {
 
         let node_handle = NodeHandle::new(lsp_node);
 
-        nigiri::try_cmd_repeatedly(nigiri::fund_lnd_node, 0.5, 10, HALF_SEC).unwrap();
+        // to open multiple channels in the same block multiple UTXOs are required in LND
+        for _ in 0..20 {
+            nigiri::try_cmd_repeatedly(nigiri::fund_lnd_node, 0.5, 10, HALF_SEC).unwrap();
+        }
 
         node_handle
     }

--- a/tests/chain_sync_test.rs
+++ b/tests/chain_sync_test.rs
@@ -161,6 +161,7 @@ mod chain_sync_test {
         sleep(Duration::from_secs(10));
 
         assert_eq!(node.get_node_info().num_channels, 3);
+        assert_eq!(node.get_node_info().num_usable_channels, 3);
     }
 
     fn setup() -> NodeHandle {

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -213,8 +213,9 @@ pub mod nigiri {
         ]);
         if !output.status.success() {
             return Err(format!(
-                "Command `lnd openchannel --private {} 1000000` failed",
-                node_id
+                "Command `lnd openchannel --private {} 1000000` failed: {}",
+                node_id,
+                String::from_utf8(output.stderr).unwrap()
             ));
         }
         let json: serde_json::Value =


### PR DESCRIPTION
Add a chaotic test, that opens and closes multiple channels at the same time, to see whether the internal sorting of transactions and outputs works.