### PR TITLE
Reconnect to LSP node regularly in the background

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ pub struct Config {
     pub lsp_node: NodeAddress,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NodeAddress {
     pub pub_key: String,
     pub address: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ impl LightningNode {
 
         // Step 14. Keep LDK Up-to-date with Chain Info
         // TODO: optimize how often we want to run sync. LDK-sample syncs every second and
-        // LDKLite syncs every 5 seconds. Let's try 5 seconds first and change if needed
+        //       LDKLite syncs every 5 seconds. Let's try 5 seconds first and change if needed
         let channel_manager_regular_sync = Arc::clone(&channel_manager);
         let chain_monitor_regular_sync = Arc::clone(&chain_monitor);
         let sync_handle = rt

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -58,6 +58,7 @@ interface LightningNode {
     [Throws=InitializationError]
     constructor([ByRef] Config config, RedundantStorageCallback redundant_storage_callback);
     NodeInfo get_node_info();
+    boolean connected_to_node([ByRef] NodeAddress node);
 };
 
 dictionary NodeInfo {

--- a/src/p2p_networking.rs
+++ b/src/p2p_networking.rs
@@ -1,26 +1,50 @@
-use crate::errors::RuntimeError;
+use crate::async_runtime::Handle;
+use crate::errors::{LipaError, MapToLipaError, RuntimeError};
 use crate::{NodeAddress, PeerManager};
 use bitcoin::secp256k1::PublicKey;
-use log::debug;
+use log::{debug, error, trace};
 use std::fmt;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::task::Poll;
 use std::time::Duration;
+use tokio::task::JoinHandle;
 use tokio::time::sleep;
 
 pub(crate) struct P2pConnections {}
 
 impl P2pConnections {
-    pub async fn connect_peer(
+    pub fn run_bg_connector(
         peer: &NodeAddress,
+        handle1: Handle,
+        peer_mgr: &Arc<PeerManager>,
+    ) -> Result<JoinHandle<()>, LipaError> {
+        let peer = Arc::new(LnPeer::try_from(peer)?);
+        let peer_mgr_clone = peer_mgr.clone();
+
+        let handle = handle1.spawn_repeating_task(Duration::from_secs(1), move || {
+            let peer_clone = Arc::clone(&peer);
+            let peer_manager = Arc::clone(&peer_mgr_clone);
+            async move {
+                if let Err(e) = P2pConnections::connect_peer(&peer_clone, peer_manager).await {
+                    error!(
+                        "Connecting to peer {} failed with error: {:?}",
+                        peer_clone, e
+                    )
+                }
+            }
+        });
+
+        Ok(handle)
+    }
+
+    async fn connect_peer(
+        peer: &LnPeer,
         peer_manager: Arc<PeerManager>,
     ) -> Result<(), RuntimeError> {
-        let peer = LnPeer::try_from(peer)?;
-
-        if Self::is_connected(&peer, Arc::clone(&peer_manager)) {
-            debug!("Peer {} is already connected", peer.pub_key);
+        if Self::is_connected(peer, Arc::clone(&peer_manager)) {
+            trace!("Peer {} is already connected", peer.pub_key);
             return Ok(());
         }
 
@@ -47,7 +71,7 @@ impl P2pConnections {
                 }
 
                 // Wait for the handshake to complete.
-                if Self::is_connected(&peer, Arc::clone(&peer_manager)) {
+                if Self::is_connected(peer, Arc::clone(&peer_manager)) {
                     debug!("Peer connection to {} established", peer.pub_key);
                     return Ok(());
                 } else {
@@ -69,25 +93,19 @@ impl P2pConnections {
     }
 }
 
-struct LnPeer {
-    pub_key: PublicKey,
-    address: SocketAddr,
+pub struct LnPeer {
+    pub pub_key: PublicKey,
+    pub address: SocketAddr,
 }
 
 impl TryFrom<&NodeAddress> for LnPeer {
-    type Error = RuntimeError;
+    type Error = LipaError;
 
     fn try_from(node_address: &NodeAddress) -> Result<Self, Self::Error> {
-        let pub_key = PublicKey::from_str(&node_address.pub_key).map_err(|e| {
-            RuntimeError::InvalidPubKey {
-                message: e.to_string(),
-            }
-        })?;
-        let address = SocketAddr::from_str(&node_address.address).map_err(|e| {
-            RuntimeError::InvalidAddress {
-                message: e.to_string(),
-            }
-        })?;
+        let pub_key = PublicKey::from_str(&node_address.pub_key)
+            .map_to_invalid_input("Could not parse node public key")?;
+        let address = SocketAddr::from_str(&node_address.address)
+            .map_to_invalid_input("Could not parse node address")?;
 
         Ok(Self { pub_key, address })
     }

--- a/src/p2p_networking.rs
+++ b/src/p2p_networking.rs
@@ -2,6 +2,7 @@ use crate::errors::RuntimeError;
 use crate::{NodeAddress, PeerManager};
 use bitcoin::secp256k1::PublicKey;
 use log::debug;
+use std::fmt;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -89,5 +90,35 @@ impl TryFrom<&NodeAddress> for LnPeer {
         })?;
 
         Ok(Self { pub_key, address })
+    }
+}
+
+impl fmt::Display for LnPeer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}@{}", self.pub_key, self.address)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::config::NodeAddress;
+    use crate::p2p_networking::LnPeer;
+
+    #[test]
+    fn test_conversion_from_strings() {
+        let sample_pubkey = "03beb9d00217e9cf9d485e47ffc6e6842c79d8941a755e261a796fe0c2e7ba2e53";
+        let sample_address = "1.2.3.4:9735";
+
+        let sample_node = NodeAddress {
+            pub_key: sample_pubkey.to_string(),
+            address: sample_address.to_string(),
+        };
+
+        let ln_peer = LnPeer::try_from(&sample_node).unwrap();
+
+        assert_eq!(
+            ln_peer.to_string(),
+            format!("{}@{}", sample_pubkey, sample_address)
+        );
     }
 }

--- a/src/p2p_networking.rs
+++ b/src/p2p_networking.rs
@@ -12,10 +12,10 @@ use std::time::Duration;
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 
-pub(crate) struct P2pConnections {}
+pub(crate) struct P2pConnection {}
 
-impl P2pConnections {
-    pub fn run_bg_connector(
+impl P2pConnection {
+    pub fn init_background_task(
         peer: &NodeAddress,
         runtime_handle: Handle,
         peer_manager: &Arc<PeerManager>,
@@ -27,7 +27,7 @@ impl P2pConnections {
             let peer_clone = Arc::clone(&peer);
             let peer_manager = Arc::clone(&peer_manager_clone);
             async move {
-                if let Err(e) = P2pConnections::connect_peer(&peer_clone, peer_manager).await {
+                if let Err(e) = P2pConnection::connect_peer(&peer_clone, peer_manager).await {
                     error!(
                         "Connecting to peer {} failed with error: {:?}",
                         peer_clone, e

--- a/src/p2p_networking.rs
+++ b/src/p2p_networking.rs
@@ -1,5 +1,5 @@
 use crate::async_runtime::Handle;
-use crate::errors::{LipaError, MapToLipaError, RuntimeError};
+use crate::errors::{LipaError, LipaResult, MapToLipaError, RuntimeError};
 use crate::{NodeAddress, PeerManager};
 use bitcoin::secp256k1::PublicKey;
 use log::{debug, error, trace};
@@ -19,7 +19,7 @@ impl P2pConnections {
         peer: &NodeAddress,
         handle1: Handle,
         peer_mgr: &Arc<PeerManager>,
-    ) -> Result<JoinHandle<()>, LipaError> {
+    ) -> LipaResult<JoinHandle<()>> {
         let peer = Arc::new(LnPeer::try_from(peer)?);
         let peer_mgr_clone = peer_mgr.clone();
 
@@ -101,7 +101,7 @@ pub struct LnPeer {
 impl TryFrom<&NodeAddress> for LnPeer {
     type Error = LipaError;
 
-    fn try_from(node_address: &NodeAddress) -> Result<Self, Self::Error> {
+    fn try_from(node_address: &NodeAddress) -> LipaResult<Self> {
         let pub_key = PublicKey::from_str(&node_address.pub_key)
             .map_to_invalid_input("Could not parse node public key")?;
         let address = SocketAddr::from_str(&node_address.address)

--- a/tests/chain_sync_test.rs
+++ b/tests/chain_sync_test.rs
@@ -5,7 +5,6 @@ mod setup;
 // cargo test --features nigiri -- --test-threads 1
 #[cfg(feature = "nigiri")]
 mod chain_sync_test {
-    use super::*;
     use bitcoin::hashes::hex::ToHex;
     use std::thread::sleep;
     use std::time::Duration;

--- a/tests/chain_sync_test.rs
+++ b/tests/chain_sync_test.rs
@@ -128,9 +128,7 @@ mod chain_sync_test {
         let tx_id = start_node_open_channel_without_confirm_stop_node(&node_handle);
 
         nigiri::lnd_force_close_channel(tx_id).unwrap();
-        // TODO: as soon as we regularly reconnect to peers, we can uncomment the following line
-        //      as then we'll be able to handle not being connected to our peers
-        // nigiri::lnd_stop().unwrap();
+        nigiri::lnd_stop().unwrap();
 
         nigiri::try_cmd_repeatedly(nigiri::mine_blocks, 1, 10, HALF_SEC).unwrap();
 

--- a/tests/p2p_connection_test.rs
+++ b/tests/p2p_connection_test.rs
@@ -59,9 +59,6 @@ mod p2p_connection_test {
 
         let node = NodeHandle::new(lsp_node.clone()).start().unwrap();
 
-        // Wait for the LDK to connect to the LSP (which should fail)
-        sleep(Duration::from_millis(1500));
-
         assert_eq!(node.get_node_info().num_peers, 0);
         assert!(!node.connected_to_node(&lsp_node));
 

--- a/tests/p2p_connection_test.rs
+++ b/tests/p2p_connection_test.rs
@@ -10,13 +10,16 @@ mod p2p_connection_test {
     use crate::setup::NodeHandle;
     use uniffi_lipalightninglib::config::NodeAddress;
 
+    const NIGIRI_LND_ADDR: &str = "127.0.0.1:9735";
+    const FAULTY_ADDR: &str = "127.0.0.1:9";
+
     #[test]
     fn test_successful_p2p_connection() {
         setup::nigiri::start();
         let lsp_info = setup::nigiri::query_lnd_info().unwrap();
         let lsp_node = NodeAddress {
             pub_key: lsp_info.pub_key,
-            address: "127.0.0.1:9735".to_string(),
+            address: NIGIRI_LND_ADDR.to_string(),
         };
 
         let node = NodeHandle::new(lsp_node).start().unwrap();
@@ -28,7 +31,7 @@ mod p2p_connection_test {
         let lsp_info = setup::nigiri::query_lnd_info().unwrap();
         let lsp_node = NodeAddress {
             pub_key: lsp_info.pub_key,
-            address: "127.0.0.1:9".to_string(),
+            address: FAULTY_ADDR.to_string(),
         };
         assert!(NodeHandle::new(lsp_node).start().is_err());
     }
@@ -38,7 +41,7 @@ mod p2p_connection_test {
         let lsp_info = setup::nigiri::query_lnd_info().unwrap();
         let lsp_node = NodeAddress {
             pub_key: lsp_info.pub_key,
-            address: "127.0.0.1:9735".to_string(),
+            address: NIGIRI_LND_ADDR.to_string(),
         };
         let node = NodeHandle::new(lsp_node).start().unwrap();
         assert_eq!(node.get_node_info().num_peers, 1);

--- a/tests/p2p_connection_test.rs
+++ b/tests/p2p_connection_test.rs
@@ -6,6 +6,8 @@ mod setup;
 #[cfg(feature = "nigiri")]
 mod p2p_connection_test {
     use super::*;
+    use std::thread::sleep;
+    use std::time::Duration;
 
     use crate::setup::NodeHandle;
     use uniffi_lipalightninglib::config::NodeAddress;
@@ -22,18 +24,78 @@ mod p2p_connection_test {
             address: NIGIRI_LND_ADDR.to_string(),
         };
 
-        let node = NodeHandle::new(lsp_node).start().unwrap();
-        assert_eq!(node.get_node_info().num_peers, 1)
+        let node = NodeHandle::new(lsp_node.clone()).start().unwrap();
+
+        assert_eq!(node.get_node_info().num_peers, 1);
+        assert!(node.connected_to_node(&lsp_node));
     }
 
     #[test]
     fn test_failing_p2p_connection() {
+        setup::nigiri::start();
         let lsp_info = setup::nigiri::query_lnd_info().unwrap();
         let lsp_node = NodeAddress {
             pub_key: lsp_info.pub_key,
             address: FAULTY_ADDR.to_string(),
         };
-        assert!(NodeHandle::new(lsp_node).start().is_err());
+
+        let node = NodeHandle::new(lsp_node.clone()).start().unwrap();
+
+        assert_eq!(node.get_node_info().num_peers, 0);
+        assert!(!node.connected_to_node(&lsp_node));
+    }
+
+    #[test]
+    fn test_start_node_while_lsp_is_down() {
+        let lsp_info = setup::nigiri::query_lnd_info().unwrap();
+        let lsp_node = NodeAddress {
+            pub_key: lsp_info.pub_key,
+            address: NIGIRI_LND_ADDR.to_string(),
+        };
+
+        // Let's shutdown LND, while we leave Esplora running (test should not affect chain sync)
+        setup::nigiri::pause();
+        setup::nigiri::resume_without_ln();
+
+        let node = NodeHandle::new(lsp_node.clone()).start().unwrap();
+
+        // Wait for the LDK to connect to the LSP (which should fail)
+        sleep(Duration::from_millis(1500));
+
+        assert_eq!(node.get_node_info().num_peers, 0);
+        assert!(!node.connected_to_node(&lsp_node));
+
+        // Now let's start Nigiri with LND again
+        setup::nigiri::pause();
+        setup::nigiri::resume();
+
+        // Wait for the LDK to connect to the LSP (which should now succeed)
+        sleep(Duration::from_millis(1500));
+
+        assert_eq!(node.get_node_info().num_peers, 1);
+        assert!(node.connected_to_node(&lsp_node));
+    }
+
+    #[test]
+    fn test_stop_node_while_lsp_is_down() {
+        setup::nigiri::start();
+        let lsp_info = setup::nigiri::query_lnd_info().unwrap();
+        let lsp_node = NodeAddress {
+            pub_key: lsp_info.pub_key,
+            address: NIGIRI_LND_ADDR.to_string(),
+        };
+
+        {
+            let node = NodeHandle::new(lsp_node.clone()).start().unwrap();
+
+            assert_eq!(node.get_node_info().num_peers, 1);
+            assert!(node.connected_to_node(&lsp_node));
+
+            setup::nigiri::stop();
+            sleep(Duration::from_secs(5)); // Wait for the LDK to disconnect from the LSP
+        }
+
+        // node has been dropped and thus shutdown.
     }
 
     #[test]
@@ -43,12 +105,25 @@ mod p2p_connection_test {
             pub_key: lsp_info.pub_key,
             address: NIGIRI_LND_ADDR.to_string(),
         };
-        let node = NodeHandle::new(lsp_node).start().unwrap();
+        let node = NodeHandle::new(lsp_node.clone()).start().unwrap();
+
         assert_eq!(node.get_node_info().num_peers, 1);
+        assert!(node.connected_to_node(&lsp_node));
 
-        setup::nigiri::stop();
+        setup::nigiri::pause();
+
+        // Wait for LDK to register the lost connection, as well as for the LipaNode to attempt to reconnect again, which should fail
+        sleep(Duration::from_millis(1500));
+
         assert_eq!(node.get_node_info().num_peers, 0);
+        assert!(!node.connected_to_node(&lsp_node));
 
-        // TODO: Test reconnecting (not implemented yet).
+        setup::nigiri::resume();
+
+        // Wait for the LDK to reconnect to the LSP
+        sleep(Duration::from_millis(1500));
+
+        assert_eq!(node.get_node_info().num_peers, 1);
+        assert!(node.connected_to_node(&lsp_node));
     }
 }


### PR DESCRIPTION
Check whether the Lightning protocol connection to the LSP is up every second, and if not try to reconnect.

In the current form, the reconnecting only happens towards the LSP node, which will also be the only Lightning peer for the foreseeable future.