### PR TITLE
Make `lspd` container wait for `db` container

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Start LSPD
  1. Go to `./lspd`
  2. Run `make` to generate `lnd.env` file with LND TLS certificate and macaroons
  3. Run `docker-compose up lspd` to start LSPD.
- Mind that `lspd` container depends on `db` container which takes time to start.
 
 Note: make assumes that nigiri data is in `~/.nigiri`,
 but you can customize it by `NIGIRI_DATA=./nigiri-data make clean all`.

--- a/lspd/docker-compose.yml
+++ b/lspd/docker-compose.yml
@@ -9,6 +9,12 @@ services:
       POSTGRES_USER: lipauser
       POSTGRES_PASSWORD: lipapassword
       POSTGRES_DB: lipadb
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready --username=lipauser --dbname=lipadb"]
+      interval: 3s
+      timeout: 10s
+      retries: 5
+      start_period: 3s
     volumes:
       - ./db-init.sh:/docker-entrypoint-initdb.d/db-init.sh
       - ../submodules/lspd/postgresql/migrations/:/migrations/
@@ -20,7 +26,8 @@ services:
     ports:
       - '6666:6666'
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     env_file:
       - lnd.env
     environment:


### PR DESCRIPTION
Now `docker-compose up lspd` does not fail because of starting `db`.