### PR TITLE
Print correct failing command

### DIFF
--- a/tests/zero_conf_test.rs
+++ b/tests/zero_conf_test.rs
@@ -25,7 +25,7 @@ mod zero_conf_test {
         const TEN_SATS: u64 = 10_000;
         const TWENTY_K_SATS: u64 = 20_000_000;
 
-        // With no channels, 10 sats invoice is to small to cover channel
+        // With no channels, 10 sats invoice is too small to cover channel
         // opening fees.
         let invoice = node.create_invoice(TEN_SATS, "test".to_string());
         assert_eq!(


### PR DESCRIPTION
When we print the commands that fail, we should print the very command that fails instead of some substitute.
This is for the following reasons:

- If we are shown the full command, it is easier to reproduce the error and debug what makes that command fail
- We ensure that the error message is actually correct; we must not be mislead by a wrong error message just because we change the command and forget to change the error message, (or copy-paste without changing the error message) 