### PR TITLE
Receive/Redeem incoming payments

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -71,4 +71,4 @@ jobs:
         with:
           submodules: true
       - name: Run unused dependency checker
-        run: cargo +nightly udeps --all-targets
+        run: cargo +nightly udeps

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -84,6 +84,11 @@ impl EventHandler for LipaEventHandler {
             Event::PendingHTLCsForwardable {
                 time_forwardable: _,
             } => {
+                // CAUTION:
+                // The name of this event "PendingHTLCsForwardable" is a potentially misleading.
+                // It is not only triggered when the node received HTLCs to forward to another node,
+                // but also when the node receives an HTLC for itself (incoming payment).
+
                 // The variable time_forwardable is meant to be used to obfuscate the timing
                 // of when a payment is being forwarded/accepted.
                 // For the time being (while Lipa is the only LSP for these wallets)

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -1,8 +1,8 @@
 use crate::types::ChannelManager;
 
 use bitcoin::secp256k1::PublicKey;
-use lightning::util::events::{Event, EventHandler};
-use log::{error, info};
+use lightning::util::events::{Event, EventHandler, PaymentPurpose};
+use log::{error, info, trace};
 use std::sync::Arc;
 
 pub(crate) struct LipaEventHandler {
@@ -21,17 +21,83 @@ impl LipaEventHandler {
 
 impl EventHandler for LipaEventHandler {
     fn handle_event(&self, event: &Event) {
+        trace!("Event occured: {:?}", event);
+
         match event {
             Event::FundingGenerationReady { .. } => {}
-            Event::PaymentReceived { .. } => {}
-            Event::PaymentClaimed { .. } => {}
+            Event::PaymentReceived {
+                payment_hash,
+                amount_msat,
+                purpose,
+            } => {
+                // Note: LDK will not stop an inbound payment from being paid multiple times,
+                //       so multiple PaymentReceived events may be generated for the same payment.
+                // Todo: This needs more research on what exactly is happening under the hood
+                //       and what the correct behaviour should be to deal with this situation.
+
+                let payment_preimage = match purpose {
+                    PaymentPurpose::InvoicePayment {
+                        payment_preimage, ..
+                    } => {
+                        info!(
+                            "Registered incoming invoice payment for {} msat with hash {:?}",
+                            amount_msat, payment_hash
+                        );
+                        *payment_preimage
+                    }
+                    PaymentPurpose::SpontaneousPayment(preimage) => {
+                        info!(
+                            "Registered incoming spontaneous payment for {} msat with hash {:?}",
+                            amount_msat, payment_hash
+                        );
+
+                        Some(*preimage)
+                    }
+                };
+
+                match payment_preimage {
+                    Some(preimage) => {
+                        self.channel_manager.claim_funds(preimage);
+                    }
+                    None => {
+                        error!("Failed to claim funds for payment with hash {:?}: No preimage. Failing HTLC backwards", payment_hash);
+                        self.channel_manager.fail_htlc_backwards(payment_hash);
+                    }
+                }
+            }
+            Event::PaymentClaimed {
+                payment_hash,
+                amount_msat,
+                purpose: _,
+            } => {
+                info!(
+                    "Claimed payment for {} msat with hash {:?}",
+                    amount_msat, payment_hash
+                );
+            }
             Event::PaymentSent { .. } => {}
             Event::PaymentFailed { .. } => {}
             Event::PaymentPathSuccessful { .. } => {}
             Event::PaymentPathFailed { .. } => {}
             Event::ProbeSuccessful { .. } => {}
             Event::ProbeFailed { .. } => {}
-            Event::PendingHTLCsForwardable { .. } => {}
+            Event::PendingHTLCsForwardable {
+                time_forwardable: _,
+            } => {
+                // The variable time_forwardable is meant to be used to obfuscate the timing
+                // of when a payment is being forwarded/accepted.
+                // For the time being (while Lipa is the only LSP for these wallets)
+                // this measure may only obfuscate for routing nodes on the payment path,
+                // whether a payment that is being routed through the Lipa-LSP
+                // is being routed towards a Lipa user or towards a third party node.
+                // Since the Lipa users don't forward payments anyways,
+                // the Lipa-LSP itself will always know the destination of the payment anyways.
+                // For this reason, we don't deem this timely obfuscation to provide
+                // any meaningful privacy advantage for our case and therefore
+                // do not delay the acceptance of HTLC using the time_forwardable variable for now.
+
+                self.channel_manager.process_pending_htlc_forwards();
+            }
             Event::SpendableOutputs { .. } => {}
             Event::PaymentForwarded { .. } => {}
             Event::ChannelClosed { .. } => {}

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -74,6 +74,8 @@ impl EventHandler for LipaEventHandler {
                     "Claimed payment for {} msat with hash {:?}",
                     amount_msat, payment_hash
                 );
+
+                // Todo: inform the consumer of this library that the payment was claimed
             }
             Event::PaymentSent { .. } => {}
             Event::PaymentFailed { .. } => {}

--- a/tests/chain_sync_test.rs
+++ b/tests/chain_sync_test.rs
@@ -179,7 +179,7 @@ mod chain_sync_test {
 
         // to open multiple channels in the same block multiple UTXOs are required in LND
         for _ in 0..20 {
-            nigiri::fund_lnd_node(NodeInstance::NigiriLnd, 0.5)
+            nigiri::fund_node(NodeInstance::NigiriLnd, 0.5)
         }
 
         node_handle

--- a/tests/chain_sync_test.rs
+++ b/tests/chain_sync_test.rs
@@ -12,19 +12,18 @@ mod chain_sync_test {
     use crate::setup::nigiri::{wait_for_sync, NodeInstance};
     use crate::setup::{nigiri, NodeHandle};
     use crate::try_cmd_repeatedly;
-    use uniffi_lipalightninglib::config::NodeAddress;
 
     const HALF_SEC: Duration = Duration::from_millis(500);
     const N_RETRIES: u8 = 10;
 
     #[test]
-    fn test_channel_is_confirmed_chain_only_after_6_confirmations() {
-        let node_handle = setup();
+    fn test_channel_is_confirmed_only_after_6_confirmations() {
+        let node_handle = NodeHandle::new_with_lsp_setup();
 
         let node = node_handle.start().unwrap();
         let node_id = node.get_node_info().node_pubkey.to_hex();
 
-        nigiri::lnd_node_open_channel(NodeInstance::NigiriLnd, &node_id, false).unwrap();
+        nigiri::lnd_node_open_channel(NodeInstance::LspdLnd, &node_id, false).unwrap();
 
         assert_eq!(node.get_node_info().channels_info.num_channels, 1);
         assert_eq!(node.get_node_info().channels_info.num_usable_channels, 0);
@@ -46,13 +45,12 @@ mod chain_sync_test {
 
     #[test]
     fn test_force_close_is_detected() {
-        let node_handle = setup();
+        let node_handle = NodeHandle::new_with_lsp_setup();
 
         let node = node_handle.start().unwrap();
         let node_id = node.get_node_info().node_pubkey.to_hex();
 
-        let tx_id =
-            nigiri::lnd_node_open_channel(NodeInstance::NigiriLnd, &node_id, false).unwrap();
+        let tx_id = nigiri::lnd_node_open_channel(NodeInstance::LspdLnd, &node_id, false).unwrap();
 
         try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 50);
 
@@ -61,9 +59,9 @@ mod chain_sync_test {
         assert_eq!(node.get_node_info().channels_info.num_channels, 1);
         assert_eq!(node.get_node_info().channels_info.num_usable_channels, 1);
 
-        nigiri::lnd_node_disconnect_peer(NodeInstance::NigiriLnd, node_id).unwrap();
-        nigiri::lnd_node_force_close_channel(NodeInstance::NigiriLnd, tx_id).unwrap();
-        nigiri::lnd_node_stop(NodeInstance::NigiriLnd).unwrap();
+        nigiri::lnd_node_disconnect_peer(NodeInstance::LspdLnd, node_id).unwrap();
+        nigiri::lnd_node_force_close_channel(NodeInstance::LspdLnd, tx_id).unwrap();
+        nigiri::lnd_node_stop(NodeInstance::LspdLnd).unwrap();
 
         sleep(Duration::from_secs(10));
 
@@ -78,7 +76,7 @@ mod chain_sync_test {
 
     #[test]
     fn test_channel_remains_usable_after_restart() {
-        let node_handle = setup();
+        let node_handle = NodeHandle::new_with_lsp_setup();
 
         start_node_open_confirm_channel_stop_node(&node_handle);
 
@@ -89,8 +87,8 @@ mod chain_sync_test {
     }
 
     #[test]
-    fn test_channel_is_confirmed_chain_only_after_6_confirmations_offline_node() {
-        let node_handle = setup();
+    fn test_channel_is_confirmed_only_after_6_confirmations_offline_node() {
+        let node_handle = NodeHandle::new_with_lsp_setup();
 
         start_node_open_channel_without_confirm_stop_node(&node_handle);
 
@@ -106,11 +104,11 @@ mod chain_sync_test {
 
     #[test]
     fn test_force_close_is_detected_offline_node() {
-        let node_handle = setup();
+        let node_handle = NodeHandle::new_with_lsp_setup();
 
         let tx_id = start_node_open_confirm_channel_stop_node(&node_handle);
 
-        nigiri::lnd_node_force_close_channel(NodeInstance::NigiriLnd, tx_id).unwrap();
+        nigiri::lnd_node_force_close_channel(NodeInstance::LspdLnd, tx_id).unwrap();
         // TODO: as soon as we regularly reconnect to peers, we can uncomment the following line
         //      as then we'll be able to handle not being connected to our peers
         // nigiri::lnd_stop().unwrap();
@@ -127,12 +125,12 @@ mod chain_sync_test {
 
     #[test]
     fn test_force_close_is_detected_offline_node_unconfirmed_channel() {
-        let node_handle = setup();
+        let node_handle = NodeHandle::new_with_lsp_setup();
 
         let tx_id = start_node_open_channel_without_confirm_stop_node(&node_handle);
 
-        nigiri::lnd_node_force_close_channel(NodeInstance::NigiriLnd, tx_id).unwrap();
-        nigiri::lnd_node_stop(NodeInstance::NigiriLnd).unwrap();
+        nigiri::lnd_node_force_close_channel(NodeInstance::LspdLnd, tx_id).unwrap();
+        nigiri::lnd_node_stop(NodeInstance::LspdLnd).unwrap();
 
         try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 1);
 
@@ -146,7 +144,7 @@ mod chain_sync_test {
 
     #[test]
     fn test_multiple_txs_simultaneously() {
-        let node_handle = setup();
+        let node_handle = NodeHandle::new_with_lsp_setup();
         let node = node_handle.start().unwrap();
         let node_id = node.get_node_info().node_pubkey.to_hex();
 
@@ -155,9 +153,9 @@ mod chain_sync_test {
 
         // mine a block and do the same again and remove 1 of the previously opened channels
         try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 1);
-        wait_for_sync(NodeInstance::NigiriLnd);
+        wait_for_sync(NodeInstance::LspdLnd);
         let _ = open_5_chans_close_2(&node_id);
-        nigiri::lnd_node_force_close_channel(NodeInstance::NigiriLnd, open_channels.pop().unwrap())
+        nigiri::lnd_node_force_close_channel(NodeInstance::LspdLnd, open_channels.pop().unwrap())
             .unwrap();
 
         try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 10);
@@ -167,30 +165,11 @@ mod chain_sync_test {
         assert_eq!(node.get_node_info().channels_info.num_usable_channels, 3);
     }
 
-    fn setup() -> NodeHandle {
-        nigiri::start();
-        let lsp_info = nigiri::query_lnd_node_info(NodeInstance::NigiriLnd).unwrap();
-        let lsp_node = NodeAddress {
-            pub_key: lsp_info.pub_key,
-            address: "127.0.0.1:9735".to_string(),
-        };
-
-        let node_handle = NodeHandle::new(lsp_node);
-
-        // to open multiple channels in the same block multiple UTXOs are required in LND
-        for _ in 0..20 {
-            nigiri::fund_node(NodeInstance::NigiriLnd, 0.5)
-        }
-
-        node_handle
-    }
-
     fn start_node_open_confirm_channel_stop_node(node_handle: &NodeHandle) -> String {
         let node = node_handle.start().unwrap();
         let node_id = node.get_node_info().node_pubkey.to_hex();
 
-        let tx_id =
-            nigiri::lnd_node_open_channel(NodeInstance::NigiriLnd, &node_id, false).unwrap();
+        let tx_id = nigiri::lnd_node_open_channel(NodeInstance::LspdLnd, &node_id, false).unwrap();
 
         assert_eq!(node.get_node_info().channels_info.num_channels, 1);
         assert_eq!(node.get_node_info().channels_info.num_usable_channels, 0);
@@ -209,8 +188,7 @@ mod chain_sync_test {
         let node = node_handle.start().unwrap();
         let node_id = node.get_node_info().node_pubkey.to_hex();
 
-        let tx_id =
-            nigiri::lnd_node_open_channel(NodeInstance::NigiriLnd, &node_id, false).unwrap();
+        let tx_id = nigiri::lnd_node_open_channel(NodeInstance::LspdLnd, &node_id, false).unwrap();
 
         assert_eq!(node.get_node_info().channels_info.num_channels, 1);
         assert_eq!(node.get_node_info().channels_info.num_usable_channels, 0);
@@ -223,9 +201,9 @@ mod chain_sync_test {
 
         for i in 0..5 {
             let tx_id =
-                nigiri::lnd_node_open_channel(NodeInstance::NigiriLnd, &node_id, false).unwrap();
+                nigiri::lnd_node_open_channel(NodeInstance::LspdLnd, &node_id, false).unwrap();
             if i % 2 == 0 {
-                nigiri::lnd_node_force_close_channel(NodeInstance::NigiriLnd, tx_id).unwrap();
+                nigiri::lnd_node_force_close_channel(NodeInstance::LspdLnd, tx_id).unwrap();
             } else {
                 open_channels.push(tx_id);
             }

--- a/tests/chain_sync_test.rs
+++ b/tests/chain_sync_test.rs
@@ -61,7 +61,7 @@ mod chain_sync_test {
 
         nigiri::lnd_node_disconnect_peer(NodeInstance::LspdLnd, node_id).unwrap();
         nigiri::lnd_node_force_close_channel(NodeInstance::LspdLnd, tx_id).unwrap();
-        nigiri::lnd_node_stop(NodeInstance::LspdLnd).unwrap();
+        nigiri::node_stop(NodeInstance::LspdLnd).unwrap();
 
         sleep(Duration::from_secs(10));
 
@@ -109,7 +109,7 @@ mod chain_sync_test {
         let tx_id = start_node_open_confirm_channel_stop_node(&node_handle);
 
         nigiri::lnd_node_force_close_channel(NodeInstance::LspdLnd, tx_id).unwrap();
-        nigiri::lnd_node_stop(NodeInstance::LspdLnd).unwrap();
+        nigiri::node_stop(NodeInstance::LspdLnd).unwrap();
 
         try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 1);
 
@@ -128,7 +128,7 @@ mod chain_sync_test {
         let tx_id = start_node_open_channel_without_confirm_stop_node(&node_handle);
 
         nigiri::lnd_node_force_close_channel(NodeInstance::LspdLnd, tx_id).unwrap();
-        nigiri::lnd_node_stop(NodeInstance::LspdLnd).unwrap();
+        nigiri::node_stop(NodeInstance::LspdLnd).unwrap();
 
         try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 1);
 

--- a/tests/chain_sync_test.rs
+++ b/tests/chain_sync_test.rs
@@ -9,7 +9,7 @@ mod chain_sync_test {
     use std::thread::sleep;
     use std::time::Duration;
 
-    use crate::setup::nigiri::{wait_for_sync, NodeInstance};
+    use crate::setup::nigiri::NodeInstance;
     use crate::setup::{nigiri, NodeHandle};
     use crate::try_cmd_repeatedly;
 
@@ -151,7 +151,7 @@ mod chain_sync_test {
 
         // mine a block and do the same again and remove 1 of the previously opened channels
         try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 1);
-        wait_for_sync(NodeInstance::LspdLnd);
+        nigiri::wait_for_sync(NodeInstance::LspdLnd);
         let _ = open_5_chans_close_2(&node_id);
         nigiri::lnd_node_force_close_channel(NodeInstance::LspdLnd, open_channels.pop().unwrap())
             .unwrap();

--- a/tests/chain_sync_test.rs
+++ b/tests/chain_sync_test.rs
@@ -109,9 +109,7 @@ mod chain_sync_test {
         let tx_id = start_node_open_confirm_channel_stop_node(&node_handle);
 
         nigiri::lnd_node_force_close_channel(NodeInstance::LspdLnd, tx_id).unwrap();
-        // TODO: as soon as we regularly reconnect to peers, we can uncomment the following line
-        //      as then we'll be able to handle not being connected to our peers
-        // nigiri::lnd_stop().unwrap();
+        nigiri::lnd_node_stop(NodeInstance::LspdLnd).unwrap();
 
         try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 1);
 

--- a/tests/node_info_test.rs
+++ b/tests/node_info_test.rs
@@ -12,7 +12,7 @@ mod node_info_test {
     #[test]
     fn test_get_node_info() {
         setup::nigiri::start();
-        let lsp_info = setup::nigiri::query_lnd_node_info(NodeInstance::NigiriLnd).unwrap();
+        let lsp_info = setup::nigiri::query_node_info(NodeInstance::NigiriLnd).unwrap();
         let lsp_node = NodeAddress {
             pub_key: lsp_info.pub_key,
             address: "127.0.0.1:9735".to_string(),

--- a/tests/p2p_connection_test.rs
+++ b/tests/p2p_connection_test.rs
@@ -19,7 +19,7 @@ mod p2p_connection_test {
     #[test]
     fn test_successful_p2p_connection() {
         setup::nigiri::start();
-        let lsp_info = setup::nigiri::query_lnd_node_info(NodeInstance::NigiriLnd).unwrap();
+        let lsp_info = setup::nigiri::query_node_info(NodeInstance::NigiriLnd).unwrap();
         let lsp_node = NodeAddress {
             pub_key: lsp_info.pub_key,
             address: NIGIRI_LND_ADDR.to_string(),
@@ -34,7 +34,7 @@ mod p2p_connection_test {
     #[test]
     fn test_failing_p2p_connection() {
         setup::nigiri::start();
-        let lsp_info = setup::nigiri::query_lnd_node_info(NodeInstance::NigiriLnd).unwrap();
+        let lsp_info = setup::nigiri::query_node_info(NodeInstance::NigiriLnd).unwrap();
         let lsp_node = NodeAddress {
             pub_key: lsp_info.pub_key,
             address: FAULTY_ADDR.to_string(),
@@ -48,7 +48,7 @@ mod p2p_connection_test {
 
     #[test]
     fn test_start_node_while_lsp_is_down() {
-        let lsp_info = setup::nigiri::query_lnd_node_info(NodeInstance::NigiriLnd).unwrap();
+        let lsp_info = setup::nigiri::query_node_info(NodeInstance::NigiriLnd).unwrap();
         let lsp_node = NodeAddress {
             pub_key: lsp_info.pub_key,
             address: NIGIRI_LND_ADDR.to_string(),
@@ -77,7 +77,7 @@ mod p2p_connection_test {
     #[test]
     fn test_stop_node_while_lsp_is_down() {
         setup::nigiri::start();
-        let lsp_info = setup::nigiri::query_lnd_node_info(NodeInstance::NigiriLnd).unwrap();
+        let lsp_info = setup::nigiri::query_node_info(NodeInstance::NigiriLnd).unwrap();
         let lsp_node = NodeAddress {
             pub_key: lsp_info.pub_key,
             address: NIGIRI_LND_ADDR.to_string(),
@@ -98,7 +98,7 @@ mod p2p_connection_test {
 
     #[test]
     fn test_flaky_p2p_connection() {
-        let lsp_info = setup::nigiri::query_lnd_node_info(NodeInstance::NigiriLnd).unwrap();
+        let lsp_info = setup::nigiri::query_node_info(NodeInstance::NigiriLnd).unwrap();
         let lsp_node = NodeAddress {
             pub_key: lsp_info.pub_key,
             address: NIGIRI_LND_ADDR.to_string(),

--- a/tests/receiving_payment_test.rs
+++ b/tests/receiving_payment_test.rs
@@ -179,7 +179,7 @@ mod receiving_payments_test {
         let lipa_node_id = node.get_node_info().node_pubkey.to_hex();
         assert_eq!(node.get_node_info().num_peers, 1);
 
-        let lspd_node_id = nigiri::query_lnd_node_info(NodeInstance::LspdLnd)
+        let lspd_node_id = nigiri::query_node_info(NodeInstance::LspdLnd)
             .unwrap()
             .pub_key;
 
@@ -227,7 +227,7 @@ mod receiving_payments_test {
         let lipa_node_id = node.get_node_info().node_pubkey.to_hex();
         assert_eq!(node.get_node_info().num_peers, 1);
 
-        let lspd_node_id = nigiri::query_lnd_node_info(NodeInstance::LspdLnd)
+        let lspd_node_id = nigiri::query_node_info(NodeInstance::LspdLnd)
             .unwrap()
             .pub_key;
 
@@ -249,7 +249,9 @@ mod receiving_payments_test {
         assert_eq!(node.get_node_info().channels_info.num_usable_channels, 1);
         assert!(node.get_node_info().channels_info.inbound_capacity_msat > TWENTY_K_SATS);
 
-        let invoice = node.create_invoice(TWENTY_K_SATS, "test".to_string()).unwrap();
+        let invoice = node
+            .create_invoice(TWENTY_K_SATS, "test".to_string())
+            .unwrap();
         assert!(invoice.starts_with("lnbc"));
 
         sleep(Duration::from_secs(100)); // wait for super lazy cln to consider its channels active
@@ -261,7 +263,9 @@ mod receiving_payments_test {
             TWENTY_K_SATS
         );
         assert_eq!(node.get_node_info().channels_info.outbound_capacity_msat, 0); // because of channel reserves
-        assert!(node.get_node_info().channels_info.inbound_capacity_msat < MILLION_SATS - TWENTY_K_SATS);
+        assert!(
+            node.get_node_info().channels_info.inbound_capacity_msat < MILLION_SATS - TWENTY_K_SATS
+        );
     }
 
     #[test]
@@ -272,7 +276,7 @@ mod receiving_payments_test {
         let lipa_node_id = node.get_node_info().node_pubkey.to_hex();
         assert_eq!(node.get_node_info().num_peers, 1);
 
-        let lspd_node_id = nigiri::query_lnd_node_info(NodeInstance::LspdLnd)
+        let lspd_node_id = nigiri::query_node_info(NodeInstance::LspdLnd)
             .unwrap()
             .pub_key;
 

--- a/tests/receiving_payment_test.rs
+++ b/tests/receiving_payment_test.rs
@@ -87,9 +87,7 @@ mod receiving_payments_test {
         try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 10);
         sleep(Duration::from_secs(10));
 
-        assert_eq!(node.get_node_info().channels_info.num_channels, 1);
-        assert_eq!(node.get_node_info().channels_info.num_usable_channels, 1);
-        assert!(node.get_node_info().channels_info.inbound_capacity_msat > TEN_K_SATS);
+        assert_channel_ready(&node, TEN_K_SATS);
 
         let invoice = node.create_invoice(TEN_K_SATS, "test".to_string()).unwrap();
         assert!(invoice.starts_with("lnbc"));
@@ -112,12 +110,7 @@ mod receiving_payments_test {
         try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 10);
         sleep(Duration::from_secs(10));
 
-        assert_eq!(node.get_node_info().channels_info.num_channels, 1);
-        assert_eq!(node.get_node_info().channels_info.num_usable_channels, 1);
-        assert!(
-            node.get_node_info().channels_info.inbound_capacity_msat
-                > TWENTY_K_SATS * amt_of_payments
-        );
+        assert_channel_ready(&node, TWENTY_K_SATS * amt_of_payments);
 
         for i in 1..=amt_of_payments {
             let invoice = node
@@ -229,9 +222,7 @@ mod receiving_payments_test {
         try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 10);
         sleep(Duration::from_secs(10));
 
-        assert_eq!(node.get_node_info().channels_info.num_channels, 1);
-        assert_eq!(node.get_node_info().channels_info.num_usable_channels, 1);
-        assert!(node.get_node_info().channels_info.inbound_capacity_msat > TWENTY_K_SATS * 3);
+        assert_channel_ready(&node, TWENTY_K_SATS * 3);
 
         let invoice = node
             .create_invoice(TWENTY_K_SATS, "test".to_string())
@@ -261,9 +252,7 @@ mod receiving_payments_test {
         payment_amount: u64,
         channel_size: u64,
     ) {
-        assert!(node.get_node_info().channels_info.num_channels > 0);
-        assert!(node.get_node_info().channels_info.num_usable_channels > 0);
-        assert!(node.get_node_info().channels_info.inbound_capacity_msat > payment_amount);
+        assert_channel_ready(&node, payment_amount);
 
         let invoice = node
             .create_invoice(payment_amount, "test".to_string())
@@ -281,5 +270,11 @@ mod receiving_payments_test {
             node.get_node_info().channels_info.inbound_capacity_msat
                 < channel_size - payment_amount
         ); // smaller instead of equal because of channel reserves
+    }
+
+    fn assert_channel_ready(node: &LightningNode, payment_amount: u64) {
+        assert!(node.get_node_info().channels_info.num_channels > 0);
+        assert!(node.get_node_info().channels_info.num_usable_channels > 0);
+        assert!(node.get_node_info().channels_info.inbound_capacity_msat > payment_amount);
     }
 }

--- a/tests/receiving_payment_test.rs
+++ b/tests/receiving_payment_test.rs
@@ -1,0 +1,353 @@
+mod setup;
+
+// Caution: Run these tests sequentially, otherwise they will corrupt each other,
+// because they are manipulating their environment:
+// cargo test --features nigiri -- --test-threads 1
+#[cfg(feature = "nigiri")]
+mod receiving_payments_test {
+    use bitcoin::hashes::hex::ToHex;
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    use crate::setup::nigiri::{fund_node, NodeInstance};
+    use crate::setup::{nigiri, NodeHandle};
+    use crate::try_cmd_repeatedly;
+    use uniffi_lipalightninglib::config::NodeAddress;
+
+    const THOUSAND_SATS: u64 = 1_000_000;
+    const TEN_K_SATS: u64 = 10_000_000;
+    const TWENTY_K_SATS: u64 = 20_000_000;
+    const MILLION_SATS: u64 = 1_000_000_000;
+
+    const HALF_SEC: Duration = Duration::from_millis(500);
+    const N_RETRIES: u8 = 10;
+
+    const LSPD_LND_HOST: &str = "lspd-lnd";
+    const LSPD_LND_PORT: u16 = 9739;
+
+    #[test]
+    // Test receiving an invoice on a node that does not have any channel yet
+    // resp, the channel opening is part of the payment process.
+    fn receive_payment_on_fresh_node() {
+        // todo: as soon as LSPD functionality is implemented
+    }
+
+    #[test]
+    // Test receiving an invoice on a node that already has an open channel
+    fn receive_payment_on_established_node() {
+        let node_handle = setup();
+
+        let node = node_handle.start().unwrap();
+        let node_id = node.get_node_info().node_pubkey.to_hex();
+
+        assert_eq!(node.get_node_info().num_peers, 1);
+
+        nigiri::lnd_node_open_channel(NodeInstance::LspdLnd, &node_id, false).unwrap();
+        try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 10);
+        sleep(Duration::from_secs(10));
+
+        assert_eq!(node.get_node_info().channels_info.num_channels, 1);
+        assert_eq!(node.get_node_info().channels_info.num_usable_channels, 1);
+        assert!(node.get_node_info().channels_info.inbound_capacity_msat > TWENTY_K_SATS);
+
+        let invoice = node
+            .create_invoice(TWENTY_K_SATS, "test".to_string())
+            .unwrap();
+        assert!(invoice.starts_with("lnbc"));
+
+        nigiri::lnd_pay_invoice(NodeInstance::LspdLnd, &invoice).unwrap();
+
+        assert_eq!(
+            node.get_node_info().channels_info.local_balance_msat,
+            TWENTY_K_SATS
+        );
+        assert_eq!(node.get_node_info().channels_info.outbound_capacity_msat, 0); // because of channel reserves
+        assert!(
+            node.get_node_info().channels_info.inbound_capacity_msat < MILLION_SATS - TWENTY_K_SATS
+        ); // smaller instead of equal because of channel reserves
+    }
+
+    #[test]
+    // The difference between sending 1_000 sats and 20_000 sats (test case receive_payment_on_established_node)
+    // is that receiving 1_000 sats creates a dust-HTLC, while receiving 20_000 sats does not.
+    // A dust-HTLC is an HTLC that is too small to be worth the fees to settle it.
+    fn receive_dust_htlc_payment() {
+        let node_handle = setup();
+
+        let node = node_handle.start().unwrap();
+        let node_id = node.get_node_info().node_pubkey.to_hex();
+
+        assert_eq!(node.get_node_info().num_peers, 1);
+
+        nigiri::lnd_node_open_channel(NodeInstance::LspdLnd, &node_id, false).unwrap();
+        try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 10);
+        sleep(Duration::from_secs(10));
+
+        assert_eq!(node.get_node_info().channels_info.num_channels, 1);
+        assert_eq!(node.get_node_info().channels_info.num_usable_channels, 1);
+        assert!(node.get_node_info().channels_info.inbound_capacity_msat > THOUSAND_SATS);
+
+        let invoice = node
+            .create_invoice(THOUSAND_SATS, "test".to_string())
+            .unwrap();
+        assert!(invoice.starts_with("lnbc"));
+
+        nigiri::lnd_pay_invoice(NodeInstance::LspdLnd, &invoice).unwrap();
+
+        assert_eq!(
+            node.get_node_info().channels_info.local_balance_msat,
+            THOUSAND_SATS
+        );
+        assert_eq!(node.get_node_info().channels_info.outbound_capacity_msat, 0); // because of channel reserves
+        assert!(
+            node.get_node_info().channels_info.inbound_capacity_msat < MILLION_SATS - THOUSAND_SATS
+        ); // smaller instead of equal because of channel reserves
+    }
+
+    #[test]
+    // Todo remove this test, once the bug is fixed
+    // This is kind of the opposite of a test.
+    // Instead of testing whether a feature *works*, it is here to test whether a bug still exists.
+    // This serves kind of as a reminder, as well as a description and proof of the bug.
+    // In case the bug gets fixed as a byproduct, for example through updating dependencies,
+    // this test should be removed, and the issues in the project management tools should be resolved.
+    fn dust_bug_still_exists() {
+        let node_handle = setup();
+
+        let node = node_handle.start().unwrap();
+        let node_id = node.get_node_info().node_pubkey.to_hex();
+
+        assert_eq!(node.get_node_info().num_peers, 1);
+
+        nigiri::lnd_node_open_channel(NodeInstance::LspdLnd, &node_id, false).unwrap();
+        try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 10);
+        sleep(Duration::from_secs(10));
+
+        assert_eq!(node.get_node_info().channels_info.num_channels, 1);
+        assert_eq!(node.get_node_info().channels_info.num_usable_channels, 1);
+        assert!(node.get_node_info().channels_info.inbound_capacity_msat > TEN_K_SATS);
+
+        let invoice = node.create_invoice(TEN_K_SATS, "test".to_string()).unwrap();
+        assert!(invoice.starts_with("lnbc"));
+
+        let result = nigiri::lnd_pay_invoice(NodeInstance::LspdLnd, &invoice);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn receive_multiple_payments() {
+        let amt_of_payments = 10;
+        let node_handle = setup();
+
+        let node = node_handle.start().unwrap();
+        let node_id = node.get_node_info().node_pubkey.to_hex();
+
+        assert_eq!(node.get_node_info().num_peers, 1);
+
+        nigiri::lnd_node_open_channel(NodeInstance::LspdLnd, &node_id, false).unwrap();
+        try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 10);
+        sleep(Duration::from_secs(10));
+
+        assert_eq!(node.get_node_info().channels_info.num_channels, 1);
+        assert_eq!(node.get_node_info().channels_info.num_usable_channels, 1);
+        assert!(
+            node.get_node_info().channels_info.inbound_capacity_msat
+                > TWENTY_K_SATS * amt_of_payments
+        );
+
+        for i in 1..=amt_of_payments {
+            let invoice = node
+                .create_invoice(TWENTY_K_SATS, "test".to_string())
+                .unwrap();
+            assert!(invoice.starts_with("lnbc"));
+
+            nigiri::lnd_pay_invoice(NodeInstance::LspdLnd, &invoice).unwrap();
+            assert_eq!(
+                node.get_node_info().channels_info.local_balance_msat,
+                TWENTY_K_SATS * i
+            );
+        }
+
+        assert!(node.get_node_info().channels_info.outbound_capacity_msat > 0);
+    }
+
+    #[test]
+    // Tests correctness of the routing hint within the invoice
+    fn receive_payment_from_lnd_with_hop() {
+        let node_handle = setup();
+
+        let node = node_handle.start().unwrap();
+        let lipa_node_id = node.get_node_info().node_pubkey.to_hex();
+        assert_eq!(node.get_node_info().num_peers, 1);
+
+        fund_node(NodeInstance::NigiriLnd, 0.5);
+
+        let lspd_node_id = nigiri::query_lnd_node_info(NodeInstance::LspdLnd)
+            .unwrap()
+            .pub_key;
+
+        nigiri::node_connect(
+            NodeInstance::NigiriLnd,
+            &lspd_node_id,
+            LSPD_LND_HOST,
+            LSPD_LND_PORT,
+        )
+        .unwrap();
+        sleep(Duration::from_secs(1));
+
+        nigiri::lnd_node_open_channel(NodeInstance::LspdLnd, &lipa_node_id, false).unwrap();
+        nigiri::lnd_node_open_pub_channel(NodeInstance::NigiriLnd, &lspd_node_id, false).unwrap();
+        try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 10);
+        sleep(Duration::from_secs(10));
+
+        assert_eq!(node.get_node_info().channels_info.num_channels, 1);
+        assert_eq!(node.get_node_info().channels_info.num_usable_channels, 1);
+        assert!(node.get_node_info().channels_info.inbound_capacity_msat > TWENTY_K_SATS);
+
+        let invoice = node
+            .create_invoice(TWENTY_K_SATS, "test".to_string())
+            .unwrap();
+        assert!(invoice.starts_with("lnbc"));
+
+        nigiri::lnd_pay_invoice(NodeInstance::NigiriLnd, &invoice).unwrap();
+
+        assert_eq!(
+            node.get_node_info().channels_info.local_balance_msat,
+            TWENTY_K_SATS
+        );
+        assert_eq!(node.get_node_info().channels_info.outbound_capacity_msat, 0); // because of channel reserves
+        assert!(
+            node.get_node_info().channels_info.inbound_capacity_msat < MILLION_SATS - TWENTY_K_SATS
+        ); // smaller instead of equal because of channel reserves
+    }
+
+    #[test]
+    // Tests correctness of the routing hint within the invoice
+    fn receive_payment_from_cln_with_hop() {
+        let node_handle = setup();
+
+        let node = node_handle.start().unwrap();
+        let lipa_node_id = node.get_node_info().node_pubkey.to_hex();
+        assert_eq!(node.get_node_info().num_peers, 1);
+
+        fund_node(NodeInstance::NigiriCln, 0.5);
+
+        let lspd_node_id = nigiri::query_lnd_node_info(NodeInstance::LspdLnd)
+            .unwrap()
+            .pub_key;
+
+        nigiri::node_connect(
+            NodeInstance::NigiriCln,
+            &lspd_node_id,
+            LSPD_LND_HOST,
+            LSPD_LND_PORT,
+        )
+        .unwrap();
+        sleep(Duration::from_secs(20));
+
+        nigiri::lnd_node_open_channel(NodeInstance::LspdLnd, &lipa_node_id, false).unwrap();
+        nigiri::cln_node_open_channel(NodeInstance::NigiriCln, &lspd_node_id).unwrap();
+        try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 10);
+        sleep(Duration::from_secs(10));
+
+        assert_eq!(node.get_node_info().channels_info.num_channels, 1);
+        assert_eq!(node.get_node_info().channels_info.num_usable_channels, 1);
+        assert!(node.get_node_info().channels_info.inbound_capacity_msat > TWENTY_K_SATS);
+
+        let invoice = node
+            .create_invoice(TWENTY_K_SATS, "test".to_string())
+            .unwrap();
+        assert!(invoice.starts_with("lnbc"));
+
+        sleep(Duration::from_secs(100)); // wait for super lazy cln to consider its channels active
+
+        nigiri::cln_pay_invoice(NodeInstance::NigiriCln, &invoice).unwrap();
+
+        assert_eq!(
+            node.get_node_info().channels_info.local_balance_msat,
+            TWENTY_K_SATS
+        );
+        assert_eq!(node.get_node_info().channels_info.outbound_capacity_msat, 0); // because of channel reserves
+        assert!(
+            node.get_node_info().channels_info.inbound_capacity_msat < MILLION_SATS - TWENTY_K_SATS
+        );
+    }
+
+    #[test]
+    fn receive_multiple_payments_for_same_invoice() {
+        let node_handle = setup();
+
+        let node = node_handle.start().unwrap();
+        let lipa_node_id = node.get_node_info().node_pubkey.to_hex();
+        assert_eq!(node.get_node_info().num_peers, 1);
+
+        fund_node(NodeInstance::NigiriLnd, 0.5);
+        fund_node(NodeInstance::NigiriCln, 0.5);
+
+        let lspd_node_id = nigiri::query_lnd_node_info(NodeInstance::LspdLnd)
+            .unwrap()
+            .pub_key;
+
+        nigiri::node_connect(
+            NodeInstance::NigiriLnd,
+            &lspd_node_id,
+            LSPD_LND_HOST,
+            LSPD_LND_PORT,
+        )
+        .unwrap();
+        nigiri::node_connect(
+            NodeInstance::NigiriCln,
+            &lspd_node_id,
+            LSPD_LND_HOST,
+            LSPD_LND_PORT,
+        )
+        .unwrap();
+        sleep(Duration::from_secs(20));
+
+        nigiri::lnd_node_open_channel(NodeInstance::LspdLnd, &lipa_node_id, false).unwrap();
+        nigiri::lnd_node_open_channel(NodeInstance::NigiriLnd, &lspd_node_id, false).unwrap();
+        nigiri::cln_node_open_channel(NodeInstance::NigiriCln, &lspd_node_id).unwrap();
+        try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 10);
+        sleep(Duration::from_secs(10));
+
+        assert_eq!(node.get_node_info().channels_info.num_channels, 1);
+        assert_eq!(node.get_node_info().channels_info.num_usable_channels, 1);
+        assert!(node.get_node_info().channels_info.inbound_capacity_msat > TWENTY_K_SATS * 3);
+
+        let invoice = node
+            .create_invoice(TWENTY_K_SATS, "test".to_string())
+            .unwrap();
+        assert!(invoice.starts_with("lnbc"));
+
+        sleep(Duration::from_secs(100)); // wait for super lazy cln to consider its channels active
+
+        nigiri::lnd_pay_invoice(NodeInstance::LspdLnd, &invoice).unwrap();
+        nigiri::lnd_pay_invoice(NodeInstance::NigiriLnd, &invoice).unwrap();
+        nigiri::cln_pay_invoice(NodeInstance::NigiriCln, &invoice).unwrap();
+
+        assert_eq!(
+            node.get_node_info().channels_info.local_balance_msat,
+            TWENTY_K_SATS * 3
+        );
+        assert!(node.get_node_info().channels_info.outbound_capacity_msat < TWENTY_K_SATS * 3); // smaller instead of equal because of channel reserves
+        assert!(
+            node.get_node_info().channels_info.inbound_capacity_msat
+                < MILLION_SATS - TWENTY_K_SATS * 3
+        ); // smaller instead of equal because of channel reserves
+    }
+
+    // todo move to setup
+    fn setup() -> NodeHandle {
+        nigiri::start();
+        let lsp_info = nigiri::query_lnd_node_info(NodeInstance::LspdLnd).unwrap();
+        let lsp_node = NodeAddress {
+            pub_key: lsp_info.pub_key,
+            address: "127.0.0.1:9739".to_string(),
+        };
+
+        let node_handle = NodeHandle::new(lsp_node);
+        fund_node(NodeInstance::LspdLnd, 0.5);
+
+        node_handle
+    }
+}

--- a/tests/receiving_payment_test.rs
+++ b/tests/receiving_payment_test.rs
@@ -339,15 +339,14 @@ mod receiving_payments_test {
     // todo move to setup
     fn setup() -> NodeHandle {
         nigiri::start();
+        fund_node(NodeInstance::LspdLnd, 0.5);
+
         let lsp_info = nigiri::query_lnd_node_info(NodeInstance::LspdLnd).unwrap();
         let lsp_node = NodeAddress {
             pub_key: lsp_info.pub_key,
             address: "127.0.0.1:9739".to_string(),
         };
 
-        let node_handle = NodeHandle::new(lsp_node);
-        fund_node(NodeInstance::LspdLnd, 0.5);
-
-        node_handle
+        NodeHandle::new(lsp_node)
     }
 }

--- a/tests/receiving_payment_test.rs
+++ b/tests/receiving_payment_test.rs
@@ -88,9 +88,7 @@ mod receiving_payments_test {
         sleep(Duration::from_secs(10));
 
         assert_channel_ready(&node, TEN_K_SATS);
-
-        let invoice = node.create_invoice(TEN_K_SATS, "test".to_string()).unwrap();
-        assert!(invoice.starts_with("lnbc"));
+        let invoice = issue_invoice(&node, TEN_K_SATS);
 
         let result = nigiri::lnd_pay_invoice(NodeInstance::LspdLnd, &invoice);
         assert!(result.is_err());
@@ -113,10 +111,7 @@ mod receiving_payments_test {
         assert_channel_ready(&node, TWENTY_K_SATS * amt_of_payments);
 
         for i in 1..=amt_of_payments {
-            let invoice = node
-                .create_invoice(TWENTY_K_SATS, "test".to_string())
-                .unwrap();
-            assert!(invoice.starts_with("lnbc"));
+            let invoice = issue_invoice(&node, TWENTY_K_SATS);
 
             nigiri::lnd_pay_invoice(NodeInstance::LspdLnd, &invoice).unwrap();
             assert_eq!(
@@ -223,11 +218,7 @@ mod receiving_payments_test {
         sleep(Duration::from_secs(10));
 
         assert_channel_ready(&node, TWENTY_K_SATS * 3);
-
-        let invoice = node
-            .create_invoice(TWENTY_K_SATS, "test".to_string())
-            .unwrap();
-        assert!(invoice.starts_with("lnbc"));
+        let invoice = issue_invoice(&node, TWENTY_K_SATS);
 
         sleep(Duration::from_secs(100)); // wait for super lazy cln to consider its channels active
 
@@ -253,11 +244,7 @@ mod receiving_payments_test {
         channel_size: u64,
     ) {
         assert_channel_ready(&node, payment_amount);
-
-        let invoice = node
-            .create_invoice(payment_amount, "test".to_string())
-            .unwrap();
-        assert!(invoice.starts_with("lnbc"));
+        let invoice = issue_invoice(&node, payment_amount);
 
         nigiri::pay_invoice(paying_node, &invoice).unwrap();
 
@@ -276,5 +263,14 @@ mod receiving_payments_test {
         assert!(node.get_node_info().channels_info.num_channels > 0);
         assert!(node.get_node_info().channels_info.num_usable_channels > 0);
         assert!(node.get_node_info().channels_info.inbound_capacity_msat > payment_amount);
+    }
+
+    fn issue_invoice(node: &LightningNode, payment_amount: u64) -> String {
+        let invoice = node
+            .create_invoice(payment_amount, "test".to_string())
+            .unwrap();
+        assert!(invoice.starts_with("lnbc"));
+
+        invoice
     }
 }

--- a/tests/receiving_payment_test.rs
+++ b/tests/receiving_payment_test.rs
@@ -96,13 +96,7 @@ mod receiving_payments_test {
             .unwrap()
             .pub_key;
 
-        nigiri::node_connect(
-            NodeInstance::NigiriLnd,
-            &lspd_node_id,
-            LSPD_LND_HOST,
-            LSPD_LND_PORT,
-        )
-        .unwrap();
+        connect_node_to_lsp(NodeInstance::NigiriLnd, &lspd_node_id);
         sleep(Duration::from_secs(1));
 
         nigiri::lnd_node_open_channel(NodeInstance::LspdLnd, &lipa_node_id, false).unwrap();
@@ -126,13 +120,7 @@ mod receiving_payments_test {
             .unwrap()
             .pub_key;
 
-        nigiri::node_connect(
-            NodeInstance::NigiriCln,
-            &lspd_node_id,
-            LSPD_LND_HOST,
-            LSPD_LND_PORT,
-        )
-        .unwrap();
+        connect_node_to_lsp(NodeInstance::NigiriCln, &lspd_node_id);
         sleep(Duration::from_secs(20));
 
         nigiri::lnd_node_open_channel(NodeInstance::LspdLnd, &lipa_node_id, false).unwrap();
@@ -155,20 +143,8 @@ mod receiving_payments_test {
             .unwrap()
             .pub_key;
 
-        nigiri::node_connect(
-            NodeInstance::NigiriLnd,
-            &lspd_node_id,
-            LSPD_LND_HOST,
-            LSPD_LND_PORT,
-        )
-        .unwrap();
-        nigiri::node_connect(
-            NodeInstance::NigiriCln,
-            &lspd_node_id,
-            LSPD_LND_HOST,
-            LSPD_LND_PORT,
-        )
-        .unwrap();
+        connect_node_to_lsp(NodeInstance::NigiriLnd, &lspd_node_id);
+        connect_node_to_lsp(NodeInstance::NigiriCln, &lspd_node_id);
         sleep(Duration::from_secs(20));
 
         nigiri::lnd_node_open_channel(NodeInstance::LspdLnd, &lipa_node_id, false).unwrap();
@@ -245,5 +221,9 @@ mod receiving_payments_test {
         assert!(invoice.starts_with("lnbc"));
 
         invoice
+    }
+
+    fn connect_node_to_lsp(node: NodeInstance, lsp_node_id: &str) {
+        nigiri::node_connect(node, lsp_node_id, LSPD_LND_HOST, LSPD_LND_PORT).unwrap();
     }
 }

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -262,7 +262,7 @@ pub mod nigiri {
 
     pub fn query_lnd_node_info(node: NodeInstance) -> Result<RemoteNodeInfo, String> {
         let sub_cmd = &["getinfo"];
-        let cmd = [get_lnd_node_prefix(node), sub_cmd].concat();
+        let cmd = [get_node_prefix(node), sub_cmd].concat();
 
         let output = exec(cmd.as_slice());
         if !output.status.success() {
@@ -277,7 +277,7 @@ pub mod nigiri {
 
     pub fn query_cln_node_info(node: NodeInstance) -> Result<String, String> {
         let sub_cmd = &["getinfo"];
-        let cmd = [get_lnd_node_prefix(node), sub_cmd].concat();
+        let cmd = [get_node_prefix(node), sub_cmd].concat();
 
         let output = exec(cmd.as_slice());
         if !output.status.success() {
@@ -325,7 +325,7 @@ pub mod nigiri {
 
     pub fn get_lnd_node_funding_address(node: NodeInstance) -> Result<String, String> {
         let sub_cmd = &["newaddress", "p2wkh"];
-        let cmd = [get_lnd_node_prefix(node), sub_cmd].concat();
+        let cmd = [get_node_prefix(node), sub_cmd].concat();
 
         let output = exec(cmd.as_slice());
         if !output.status.success() {
@@ -339,7 +339,7 @@ pub mod nigiri {
 
     pub fn get_cln_node_funding_address(node: NodeInstance) -> Result<String, String> {
         let sub_cmd = &["newaddr"];
-        let cmd = [get_lnd_node_prefix(node), sub_cmd].concat();
+        let cmd = [get_node_prefix(node), sub_cmd].concat();
 
         let output = exec(cmd.as_slice());
         if !output.status.success() {
@@ -359,7 +359,7 @@ pub mod nigiri {
     ) -> Result<(), String> {
         let address = format!("{}@{}:{}", target_node_id, target_node_host, target_port);
         let sub_cmd = vec!["connect", &address];
-        let cmd = [get_lnd_node_prefix(node), &sub_cmd].concat();
+        let cmd = [get_node_prefix(node), &sub_cmd].concat();
 
         let output = exec(cmd.as_slice());
         if !output.status.success() {
@@ -385,7 +385,7 @@ pub mod nigiri {
             sub_cmd.insert(2, "--zero_conf");
         }
 
-        let cmd = [get_lnd_node_prefix(node), &sub_cmd].concat();
+        let cmd = [get_node_prefix(node), &sub_cmd].concat();
 
         let output = exec(cmd.as_slice());
         if !output.status.success() {
@@ -419,7 +419,7 @@ pub mod nigiri {
         target_node_id: &str,
     ) -> Result<String, String> {
         let sub_cmd = vec!["fundchannel", target_node_id, "1000000"];
-        let cmd = [get_lnd_node_prefix(node), &sub_cmd].concat();
+        let cmd = [get_node_prefix(node), &sub_cmd].concat();
 
         let output = exec(cmd.as_slice());
         if !output.status.success() {
@@ -434,7 +434,7 @@ pub mod nigiri {
 
     pub fn lnd_pay_invoice(node: NodeInstance, invoice: &str) -> Result<(), String> {
         let sub_cmd = &["payinvoice", "--force", invoice];
-        let cmd = [get_lnd_node_prefix(node), sub_cmd].concat();
+        let cmd = [get_node_prefix(node), sub_cmd].concat();
 
         let output = exec(cmd.as_slice());
         if !output.status.success() {
@@ -446,7 +446,7 @@ pub mod nigiri {
 
     pub fn cln_pay_invoice(node: NodeInstance, invoice: &str) -> Result<(), String> {
         let sub_cmd = &["pay", invoice];
-        let cmd = [get_lnd_node_prefix(node), sub_cmd].concat();
+        let cmd = [get_node_prefix(node), sub_cmd].concat();
 
         let output = exec(cmd.as_slice());
         if !output.status.success() {
@@ -458,7 +458,7 @@ pub mod nigiri {
 
     pub fn lnd_node_disconnect_peer(node: NodeInstance, node_id: String) -> Result<(), String> {
         let sub_cmd = &["disconnect", &node_id];
-        let cmd = [get_lnd_node_prefix(node), sub_cmd].concat();
+        let cmd = [get_node_prefix(node), sub_cmd].concat();
 
         let output = exec(cmd.as_slice());
 
@@ -474,7 +474,7 @@ pub mod nigiri {
         funding_txid: String,
     ) -> Result<(), String> {
         let sub_cmd = &["closechannel", "--force", &funding_txid];
-        let cmd = [get_lnd_node_prefix(node), sub_cmd].concat();
+        let cmd = [get_node_prefix(node), sub_cmd].concat();
 
         let output = exec(cmd.as_slice());
         if !output.status.success() {
@@ -488,7 +488,7 @@ pub mod nigiri {
 
     pub fn lnd_node_stop(node: NodeInstance) -> Result<(), String> {
         let sub_cmd = &["stop"];
-        let cmd = [get_lnd_node_prefix(node), sub_cmd].concat();
+        let cmd = [get_node_prefix(node), sub_cmd].concat();
 
         let output = exec(cmd.as_slice());
         if !output.status.success() {
@@ -511,7 +511,7 @@ pub mod nigiri {
             .expect("Failed to run command")
     }
 
-    fn get_lnd_node_prefix(node: NodeInstance) -> &'static [&'static str] {
+    fn get_node_prefix(node: NodeInstance) -> &'static [&'static str] {
         match node {
             NodeInstance::NigiriCln => NIGIRI_CLN_CMD_PREFIX,
             NodeInstance::NigiriLnd => NIGIRI_LND_CMD_PREFIX,

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -485,7 +485,17 @@ pub mod nigiri {
         Ok(())
     }
 
-    pub fn lnd_node_stop(node: NodeInstance) -> Result<(), String> {
+    pub fn node_stop(node: NodeInstance) -> Result<(), String> {
+        match node {
+            NodeInstance::LspdLnd => {
+                stop_lspd();
+                Ok(())
+            }
+            _ => nigiri_node_stop(node),
+        }
+    }
+
+    pub fn nigiri_node_stop(node: NodeInstance) -> Result<(), String> {
         let sub_cmd = &["stop"];
         let cmd = [get_node_prefix(node), sub_cmd].concat();
 

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -208,16 +208,19 @@ pub mod nigiri {
     }
 
     pub fn wait_for_sync(node: NodeInstance) {
-        let mut counter = 0;
-        while query_node_info(node).is_err() || !query_node_info(node).unwrap().synced {
-            counter += 1;
-            if counter > 10 {
-                panic!("Failed to start {:?}", node);
-            }
-            debug!("{:?} is NOT synced", node);
+        for _ in 0..10 {
+            debug!("{:?} is NOT synced yet, waiting...", node);
             sleep(Duration::from_millis(500));
+
+            if let Ok(info) = query_node_info(node) {
+                if info.synced {
+                    debug!("{:?} is synced", node);
+                    return;
+                }
+            }
         }
-        debug!("{:?} is synced", node);
+
+        panic!("Failed to start {:?}. Not synced after 5 sec.", node);
     }
 
     fn wait_for_esplora() {

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -424,6 +424,13 @@ pub mod nigiri {
         Ok(funding_txid)
     }
 
+    pub fn pay_invoice(node: NodeInstance, invoice: &str) -> Result<(), String> {
+        match node {
+            NodeInstance::NigiriCln => cln_pay_invoice(node, invoice),
+            _ => lnd_pay_invoice(node, invoice),
+        }
+    }
+
     pub fn lnd_pay_invoice(node: NodeInstance, invoice: &str) -> Result<(), String> {
         let sub_cmd = &["payinvoice", "--force", invoice];
         let cmd = [get_node_prefix(node), sub_cmd].concat();

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -239,7 +239,7 @@ pub mod nigiri {
     }
 
     pub fn fund_lnd_node(node: NodeInstance, amount_btc: f32) {
-        let address = get_lnd_node_address(node).unwrap();
+        let address = get_lnd_node_funding_address(node).unwrap();
         try_cmd_repeatedly!(
             fund_address,
             10,
@@ -259,7 +259,7 @@ pub mod nigiri {
         Ok(())
     }
 
-    pub fn get_lnd_node_address(node: NodeInstance) -> Result<String, String> {
+    pub fn get_lnd_node_funding_address(node: NodeInstance) -> Result<String, String> {
         let sub_cmd = &["newaddress", "p2wkh"];
         let cmd = [get_lnd_node_prefix(node), sub_cmd].concat();
 

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -90,7 +90,7 @@ impl NodeHandle {
     pub fn new_with_lsp_setup() -> NodeHandle {
         nigiri::start();
 
-        // to open multiple channels in the same block multiple UTXOs are required in LND
+        // to open multiple channels in the same block, multiple UTXOs are required
         for _ in 0..10 {
             nigiri::fund_node(NodeInstance::LspdLnd, 0.5);
             nigiri::fund_node(NodeInstance::NigiriLnd, 0.5);

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -220,7 +220,7 @@ pub mod nigiri {
 
     fn wait_for_sync_lnd(node: NodeInstance) {
         let mut counter = 0;
-        while query_lnd_node_info(node).is_err() {
+        while query_lnd_node_info(node).is_err() || !query_lnd_node_info(node).unwrap().synced {
             counter += 1;
             if counter > 10 {
                 panic!("Failed to start {:?}", node);

--- a/tests/zero_conf_test.rs
+++ b/tests/zero_conf_test.rs
@@ -27,6 +27,7 @@ mod zero_conf_test {
 
         // With no channels, 10 sats invoice is too small to cover channel
         // opening fees.
+        assert!(node.get_node_info().channels_info.inbound_capacity_msat < TEN_SATS);
         let invoice = node.create_invoice(TEN_SATS, "test".to_string());
         assert_eq!(
 	    invoice.unwrap_err().to_string(),
@@ -39,6 +40,7 @@ mod zero_conf_test {
         sleep(Duration::from_secs(5));
 
         // With a channel, 10 sats invoice is perfectly fine.
+        assert!(node.get_node_info().channels_info.inbound_capacity_msat > TEN_SATS);
         let invoice = node.create_invoice(TEN_SATS, "test".to_string());
         assert!(invoice.unwrap().starts_with("lnbc"));
 

--- a/tests/zero_conf_test.rs
+++ b/tests/zero_conf_test.rs
@@ -9,13 +9,12 @@ mod zero_conf_test {
     use std::thread::sleep;
     use std::time::Duration;
 
-    use crate::setup::nigiri::{fund_node, NodeInstance};
+    use crate::setup::nigiri::NodeInstance;
     use crate::setup::{nigiri, NodeHandle};
-    use uniffi_lipalightninglib::config::NodeAddress;
 
     #[test]
     fn test_zero_conf_channel_is_usable_without_confirmations() {
-        let node_handle = setup();
+        let node_handle = NodeHandle::new_with_lsp_setup();
 
         let node = node_handle.start().unwrap();
         let node_id = node.get_node_info().node_pubkey.to_hex();
@@ -46,20 +45,5 @@ mod zero_conf_test {
 
         assert_eq!(node.get_node_info().channels_info.num_channels, 1);
         assert_eq!(node.get_node_info().channels_info.num_usable_channels, 1);
-    }
-
-    fn setup() -> NodeHandle {
-        nigiri::start();
-        let lsp_info = nigiri::query_lnd_node_info(NodeInstance::LspdLnd).unwrap();
-        let lsp_node = NodeAddress {
-            pub_key: lsp_info.pub_key,
-            address: "127.0.0.1:9739".to_string(),
-        };
-
-        let node_handle = NodeHandle::new(lsp_node);
-
-        fund_node(NodeInstance::LspdLnd, 0.5);
-
-        node_handle
     }
 }

--- a/tests/zero_conf_test.rs
+++ b/tests/zero_conf_test.rs
@@ -9,7 +9,7 @@ mod zero_conf_test {
     use std::thread::sleep;
     use std::time::Duration;
 
-    use crate::setup::nigiri::{fund_lnd_node, NodeInstance};
+    use crate::setup::nigiri::{fund_node, NodeInstance};
     use crate::setup::{nigiri, NodeHandle};
     use uniffi_lipalightninglib::config::NodeAddress;
 
@@ -58,7 +58,7 @@ mod zero_conf_test {
 
         let node_handle = NodeHandle::new(lsp_node);
 
-        fund_lnd_node(NodeInstance::LspdLnd, 0.5);
+        fund_node(NodeInstance::LspdLnd, 0.5);
 
         node_handle
     }


### PR DESCRIPTION
When 3L receives incoming payments, LDK informs it through the event handler.
If it wants to accept these payments, it has to redeem it.

Contains mostly integration tests.