### PR TITLE
Unify tests modules naming

### DIFF
--- a/src/async_runtime.rs
+++ b/src/async_runtime.rs
@@ -112,7 +112,7 @@ impl RepeatingTaskHandle {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -89,7 +89,7 @@ fn hmac256(key: &[u8], data: &[u8]) -> Vec<u8> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use bitcoin::hashes::hex::{FromHex, ToHex};
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -144,7 +144,7 @@ impl<T> MapToLipaErrorForUnitType<T> for Result<T, ()> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/src/keys_manager.rs
+++ b/src/keys_manager.rs
@@ -54,7 +54,7 @@ fn derive_secret_from_mnemonic(mnemonic: Mnemonic, passphrase: String) -> Secret
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use bitcoin::hashes::hex::FromHex;
 

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -146,7 +146,7 @@ pub(crate) fn calculate_fee(value_msat: u64, fee: &LspFee) -> u64 {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use bitcoin::hashes::hex::{FromHex, ToHex};
 

--- a/src/p2p_networking.rs
+++ b/src/p2p_networking.rs
@@ -117,7 +117,7 @@ impl fmt::Display for LnPeer {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::config::NodeAddress;
     use crate::p2p_networking::LnPeer;
 

--- a/src/storage_persister.rs
+++ b/src/storage_persister.rs
@@ -281,7 +281,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     use crate::keys_manager::init_keys_manager;

--- a/src/tx_broadcaster.rs
+++ b/src/tx_broadcaster.rs
@@ -27,7 +27,7 @@ impl BroadcasterInterface for TxBroadcaster {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     use bitcoin::consensus::deserialize;


### PR DESCRIPTION
As the _holy_ book shows in the example, we should use `tests` module name for tests:
```rust
#[cfg(test)]
mod tests {
    #[test]
    fn it_works() {
        let result = 2 + 2;
        assert_eq!(result, 4);
    }
}
```
https://doc.rust-lang.org/book/ch11-01-writing-tests.html#the-anatomy-of-a-test-function