### PR TITLE
Implement polling fee estimator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Install Cross
+        run: cargo install cross --locked
       - name: Build target
         uses: actions-rs/cargo@v1
         with:
@@ -80,6 +82,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Install Cross
+        run: cargo install cross --locked
       - name: Build target
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -32,6 +32,8 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Cross
+        run: cargo install cross --locked
       - name: Build target
         uses: actions-rs/cargo@v1
         with:
@@ -76,6 +78,8 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Cross
+        run: cargo install cross --locked
       - name: Build target
         uses: actions-rs/cargo@v1
         with:

--- a/src/esplora_client.rs
+++ b/src/esplora_client.rs
@@ -1,4 +1,5 @@
 use crate::errors::*;
+use std::collections::HashMap;
 
 use bitcoin::{BlockHash, BlockHeader, Transaction, Txid};
 use esplora_client::blocking::BlockingClient;
@@ -154,5 +155,11 @@ impl EsploraClient {
         self.client
             .broadcast(tx)
             .map_to_runtime_error("Esplora failed to broadcast tx")
+    }
+
+    pub fn get_fee_estimates(&self) -> LipaResult<HashMap<String, f64>> {
+        self.client
+            .get_fee_estimates()
+            .map_to_runtime_error("Esplora failed to get fee estimates")
     }
 }

--- a/src/fee_estimator.rs
+++ b/src/fee_estimator.rs
@@ -118,23 +118,11 @@ fn get_ldk_estimate_from_esplora_estimates(
 impl LdkFeeEstimator for FeeEstimator {
     fn get_est_sat_per_1000_weight(&self, confirmation_target: ConfirmationTarget) -> u32 {
         match self.network {
-            Network::Bitcoin => match confirmation_target {
-                ConfirmationTarget::Background => self
-                    .fees
-                    .get(&ConfirmationTarget::Background)
-                    .unwrap()
-                    .load(Ordering::Acquire),
-                ConfirmationTarget::Normal => self
-                    .fees
-                    .get(&ConfirmationTarget::Normal)
-                    .unwrap()
-                    .load(Ordering::Acquire),
-                ConfirmationTarget::HighPriority => self
-                    .fees
-                    .get(&ConfirmationTarget::HighPriority)
-                    .unwrap()
-                    .load(Ordering::Acquire),
-            },
+            Network::Bitcoin => self
+                .fees
+                .get(&confirmation_target)
+                .unwrap()
+                .load(Ordering::Acquire),
             _ => match confirmation_target {
                 ConfirmationTarget::Background => BACKGROUND_DEFAULT,
                 ConfirmationTarget::Normal => NORMAL_DEFAULT,
@@ -149,7 +137,9 @@ mod tests {
     use super::*;
     use crate::async_runtime::AsyncRuntime;
 
-    const ESPLORA_API_URL: &str = "";
+    // 9 is a discard port
+    // See https://en.wikipedia.org/wiki/Port_(computer_networking)
+    const ESPLORA_API_URL: &str = "http://localhost:9";
 
     #[test]
     fn fee_is_above_minimum() {

--- a/src/fee_estimator.rs
+++ b/src/fee_estimator.rs
@@ -1,14 +1,132 @@
+use crate::async_runtime::Handle;
+use crate::esplora_client::EsploraClient;
 use lightning::chain::chaininterface::{ConfirmationTarget, FeeEstimator as LdkFeeEstimator};
+use log::{debug, error};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 
-pub struct FeeEstimator;
+const FEE_ESTIMATE_POLLING_INTERVAL: u64 = 60;
+
+const BACKGROUND_CONFIRM_IN_BLOCKS: &str = "25";
+const NORMAL_CONFIRM_IN_BLOCKS: &str = "6";
+const HIGH_PRIORITY_CONFIRM_IN_BLOCKS: &str = "1";
+
+const MIN_FEERATE: u32 = 253; // 1 sats per byte
+
+const BACKGROUND_DEFAULT: u32 = MIN_FEERATE; // 1 sats per byte
+const NORMAL_DEFAULT: u32 = 2000; // 8 sats per byte
+const HIGH_PRIORITY_DEFAULT: u32 = 5000; // 20 sats per byte
+
+pub(crate) struct FeeEstimator {
+    fees: Arc<HashMap<ConfirmationTarget, AtomicU32>>,
+}
+
+impl FeeEstimator {
+    pub fn new(esplora_client: Arc<EsploraClient>, runtime_handle: Handle) -> Self {
+        // Init fees
+        let mut fees: HashMap<ConfirmationTarget, AtomicU32> = HashMap::new();
+        fees.insert(
+            ConfirmationTarget::Background,
+            AtomicU32::new(BACKGROUND_DEFAULT),
+        );
+        fees.insert(ConfirmationTarget::Normal, AtomicU32::new(NORMAL_DEFAULT));
+        fees.insert(
+            ConfirmationTarget::HighPriority,
+            AtomicU32::new(HIGH_PRIORITY_DEFAULT),
+        );
+        let fees = Arc::new(fees);
+
+        // Launch polling background task
+        let esplora_client_poll = Arc::clone(&esplora_client);
+        let fees_poll = Arc::clone(&fees);
+        runtime_handle.spawn_repeating_task(
+            Duration::from_secs(FEE_ESTIMATE_POLLING_INTERVAL),
+            move || {
+                let esplora_client_poll = Arc::clone(&esplora_client_poll);
+                let fees_poll = Arc::clone(&fees_poll);
+                async move {
+                    match esplora_client_poll.get_fee_estimates() {
+                        Ok(estimates) => {
+                            let background_estimate = get_ldk_estimate_from_esplora_estimates(
+                                &estimates,
+                                BACKGROUND_CONFIRM_IN_BLOCKS,
+                                BACKGROUND_DEFAULT,
+                            );
+                            let normal_estimate = get_ldk_estimate_from_esplora_estimates(
+                                &estimates,
+                                NORMAL_CONFIRM_IN_BLOCKS,
+                                NORMAL_DEFAULT,
+                            );
+                            let high_priority_estimate = get_ldk_estimate_from_esplora_estimates(
+                                &estimates,
+                                HIGH_PRIORITY_CONFIRM_IN_BLOCKS,
+                                HIGH_PRIORITY_DEFAULT,
+                            );
+
+                            // Multi-line print done with a single debug! so that the lines can't 
+                            // get separated by other debug prints
+                            debug!("FeeEstimator fetched new estimates from esplora: \n    Background: {}\n    Normal: {} \n    HighPriority: {}", background_estimate, normal_estimate, high_priority_estimate);
+
+                            fees_poll
+                                .get(&ConfirmationTarget::Background)
+                                .unwrap()
+                                .store(background_estimate, Ordering::Release);
+                            fees_poll
+                                .get(&ConfirmationTarget::Normal)
+                                .unwrap()
+                                .store(normal_estimate, Ordering::Release);
+                            fees_poll
+                                .get(&ConfirmationTarget::HighPriority)
+                                .unwrap()
+                                .store(high_priority_estimate, Ordering::Release);
+                        }
+                        Err(e) => {
+                            error!("Failed to get fee estimates from esplora: {}", e);
+                        }
+                    }
+                }
+            },
+        );
+
+        Self { fees }
+    }
+}
+
+fn get_ldk_estimate_from_esplora_estimates(
+    esplora_estimates: &HashMap<String, f64>,
+    confirm_in_blocks: &str,
+    default: u32,
+) -> u32 {
+    let background_estimate = match esplora_estimates.get(confirm_in_blocks) {
+        None => {
+            error!("Failed to get fee estimates: Esplora didn't provide an estimate for confirmation in {} blocks", confirm_in_blocks);
+            return default;
+        }
+        Some(e) => e,
+    };
+    std::cmp::max((background_estimate * 250.0).round() as u32, MIN_FEERATE)
+}
 
 impl LdkFeeEstimator for FeeEstimator {
     fn get_est_sat_per_1000_weight(&self, confirmation_target: ConfirmationTarget) -> u32 {
-        // TODO: Implement.
         match confirmation_target {
-            ConfirmationTarget::Background => 253,
-            ConfirmationTarget::Normal => 1000,
-            ConfirmationTarget::HighPriority => 2000,
+            ConfirmationTarget::Background => self
+                .fees
+                .get(&ConfirmationTarget::Background)
+                .unwrap()
+                .load(Ordering::Acquire),
+            ConfirmationTarget::Normal => self
+                .fees
+                .get(&ConfirmationTarget::Normal)
+                .unwrap()
+                .load(Ordering::Acquire),
+            ConfirmationTarget::HighPriority => self
+                .fees
+                .get(&ConfirmationTarget::HighPriority)
+                .unwrap()
+                .load(Ordering::Acquire),
         }
     }
 }
@@ -16,10 +134,17 @@ impl LdkFeeEstimator for FeeEstimator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::async_runtime::AsyncRuntime;
+
+    const ESPLORA_API_URL: &str = "";
 
     #[test]
     fn fee_is_above_minimum() {
-        let client = FeeEstimator {};
+        let rt = AsyncRuntime::new().unwrap();
+        let client = FeeEstimator::new(
+            Arc::new(EsploraClient::new(ESPLORA_API_URL).unwrap()),
+            rt.handle(),
+        );
         assert!(client.get_est_sat_per_1000_weight(ConfirmationTarget::Background) >= 253);
         assert!(client.get_est_sat_per_1000_weight(ConfirmationTarget::Normal) >= 253);
         assert!(client.get_est_sat_per_1000_weight(ConfirmationTarget::HighPriority) >= 253);
@@ -27,7 +152,11 @@ mod tests {
 
     #[test]
     fn fee_is_reasonable() {
-        let client = FeeEstimator {};
+        let rt = AsyncRuntime::new().unwrap();
+        let client = FeeEstimator::new(
+            Arc::new(EsploraClient::new(ESPLORA_API_URL).unwrap()),
+            rt.handle(),
+        );
         assert!(client.get_est_sat_per_1000_weight(ConfirmationTarget::Background) < 1000000);
         assert!(client.get_est_sat_per_1000_weight(ConfirmationTarget::Normal) < 5000000);
         assert!(client.get_est_sat_per_1000_weight(ConfirmationTarget::HighPriority) < 10000000);
@@ -35,7 +164,11 @@ mod tests {
 
     #[test]
     fn fee_is_ordered() {
-        let client = FeeEstimator {};
+        let rt = AsyncRuntime::new().unwrap();
+        let client = FeeEstimator::new(
+            Arc::new(EsploraClient::new(ESPLORA_API_URL).unwrap()),
+            rt.handle(),
+        );
         let background = client.get_est_sat_per_1000_weight(ConfirmationTarget::Background);
         let normal = client.get_est_sat_per_1000_weight(ConfirmationTarget::Normal);
         let high_priority = client.get_est_sat_per_1000_weight(ConfirmationTarget::HighPriority);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,11 @@ impl LightningNode {
         );
 
         // Step 1. Initialize the FeeEstimator
-        let fee_estimator = Arc::new(FeeEstimator::new(Arc::clone(&esplora_client), rt.handle()));
+        let fee_estimator = Arc::new(FeeEstimator::new(
+            Arc::clone(&esplora_client),
+            rt.handle(),
+            config.network,
+        ));
 
         // Step 2. Initialize the Logger
         let logger = Arc::new(LightningLogger {});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ pub struct LightningNode {
     rgs_url: String,
     rapid_sync: Arc<RapidGossipSync>,
     invoice_payer: Arc<InvoicePayer>,
+    fee_estimator_handle: RepeatingTaskHandle,
 }
 
 impl LightningNode {
@@ -118,9 +119,22 @@ impl LightningNode {
         // Step 1. Initialize the FeeEstimator
         let fee_estimator = Arc::new(FeeEstimator::new(
             Arc::clone(&esplora_client),
-            rt.handle(),
             config.network,
         ));
+
+        // TODO: decide how often to run fee estimation poll
+        let fee_estimator_poll = Arc::clone(&fee_estimator);
+        let fee_estimator_handle =
+            rt.handle()
+                .spawn_repeating_task(Duration::from_secs(60), move || {
+                    let fee_estimator_poll = Arc::clone(&fee_estimator_poll);
+                    async move {
+                        match fee_estimator_poll.poll_updates() {
+                            Ok(_) => {}
+                            Err(e) => error!("Failed to get fee estimates from esplora: {}", e),
+                        }
+                    }
+                });
 
         // Step 2. Initialize the Logger
         let logger = Arc::new(LightningLogger {});
@@ -344,6 +358,7 @@ impl LightningNode {
             rgs_url: config.rgs_url.clone(),
             rapid_sync,
             invoice_payer,
+            fee_estimator_handle,
         })
     }
 
@@ -518,6 +533,7 @@ impl Drop for LightningNode {
     fn drop(&mut self) {
         self.p2p_connector_handle.blocking_shutdown();
         self.sync_handle.blocking_shutdown();
+        self.fee_estimator_handle.blocking_shutdown();
 
         // TODO: Stop reconnecting to peers
         self.peer_manager.disconnect_all_peers();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ impl LightningNode {
         );
 
         // Step 1. Initialize the FeeEstimator
-        let fee_estimator = Arc::new(FeeEstimator {});
+        let fee_estimator = Arc::new(FeeEstimator::new(Arc::clone(&esplora_client), rt.handle()));
 
         // Step 2. Initialize the Logger
         let logger = Arc::new(LightningLogger {});


### PR DESCRIPTION
Implemented the FeeEstimator using an approach very similar to the one in LDK-Sample and Sensei. Main difference is that it uses esplora as the backend instead of bitcoind.

I've done basic manual testing to verify that it works. 

I'm not sure how to write automated tests for this estimator because:
* Unit tests aren't a good fit due to external services being required
* Integration tests aren't a good fit due to FeeEstimation not being exposed in 3L's interface

Current unit tests confirm good behavior when an unavailable esplora is used.

The new FeeEstimator implementation is being bypassed when running on test networks (testnet, regtest, etc) because otherwise, channels can't be opened between LDK and LND. LND defaults to a high fee when on test networks. So high (relative to LDK fee estimates) that LDK doesn't accept incoming channels with the error: `Peer's feerate much too high. Actual: 12500. Our expected upper limit: 6250`. Despite ignoring the fee estimates from esplora, I left the background task running so that testing scenarios remain realistic (network traffic + number of running tasks).