### PR TITLE
Integration test improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.2.0
       - name: Build
         run: cargo build --verbose
       - name: Run unit tests
@@ -57,6 +59,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.2.0
       - name: Install Cross
         run: cargo install cross --locked
       - name: Build target
@@ -83,6 +87,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.2.0
       - name: Install Cross
         run: cargo install cross --locked
       - name: Build target

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.2.0
       - name: Run Nigiri
         uses: vulpemventures/nigiri-github-action@master
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,8 @@ uniffi = "0.22.0"
 
 [dev-dependencies]
 serde_json = "1.0"
-simplelog = { version ="0.12.0", features = ["test"] }
+serial_test = { version =  "0.10.0", features = ["file_locks"] }
+simplelog = { version = "0.12.0", features = ["test"] }
 storage-mock = { path = "util/storage-mock" }
 
 [target.'cfg(target_os = "ios")'.dependencies]

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test:
 integrationtests: FILE = *
 integrationtests: TEST = ''
 integrationtests:
-	cargo test --features nigiri --test '$(FILE)' -- --test-threads 1 $(TEST)
+	cargo test --features nigiri --test '$(FILE)' -- $(TEST)
 
 .PHONY: testall
 testall: test integrationtests

--- a/tests/chain_sync_test.rs
+++ b/tests/chain_sync_test.rs
@@ -1,11 +1,9 @@
 mod setup;
 
-// Caution: Run these tests sequentially, otherwise they will corrupt each other,
-// because they are manipulating their environment:
-// cargo test --features nigiri -- --test-threads 1
 #[cfg(feature = "nigiri")]
 mod chain_sync_test {
     use bitcoin::hashes::hex::ToHex;
+    use serial_test::file_serial;
     use std::thread::sleep;
     use std::time::Duration;
 
@@ -17,6 +15,8 @@ mod chain_sync_test {
     const N_RETRIES: u8 = 10;
 
     #[test]
+    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
+    #[file_serial]
     fn test_react_to_events() {
         let node_handle = NodeHandle::new_with_lsp_setup();
 
@@ -77,6 +77,8 @@ mod chain_sync_test {
     }
 
     #[test]
+    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
+    #[file_serial]
     fn test_react_to_events_with_offline_node() {
         let node_handle = NodeHandle::new_with_lsp_setup();
 
@@ -117,6 +119,8 @@ mod chain_sync_test {
     }
 
     #[test]
+    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
+    #[file_serial]
     fn test_force_close_is_detected_offline_node_unconfirmed_channel() {
         let node_handle = NodeHandle::new_with_lsp_setup();
 

--- a/tests/chain_sync_test.rs
+++ b/tests/chain_sync_test.rs
@@ -76,7 +76,6 @@ mod chain_sync_test {
     }
 
     #[test]
-    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
     #[file_serial]
     fn test_react_to_events_with_offline_node() {
         let node_handle = NodeHandle::new_with_lsp_setup();
@@ -118,7 +117,6 @@ mod chain_sync_test {
     }
 
     #[test]
-    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
     #[file_serial]
     fn test_force_close_is_detected_offline_node_unconfirmed_channel() {
         let node_handle = NodeHandle::new_with_lsp_setup();

--- a/tests/chain_sync_test.rs
+++ b/tests/chain_sync_test.rs
@@ -17,8 +17,7 @@ mod chain_sync_test {
     #[test]
     #[file_serial]
     fn test_react_to_events() {
-        let node_handle = NodeHandle::new_with_lsp_setup();
-
+        let node_handle = NodeHandle::new_with_lsp_setup(true);
         let node = node_handle.start().unwrap();
         let node_id = node.get_node_info().node_pubkey.to_hex();
 
@@ -78,7 +77,7 @@ mod chain_sync_test {
     #[test]
     #[file_serial]
     fn test_react_to_events_with_offline_node() {
-        let node_handle = NodeHandle::new_with_lsp_setup();
+        let node_handle = NodeHandle::new_with_lsp_setup(true);
 
         // test channel is confirmed only after 6 confirmations with offline node
         let tx_id = start_node_open_channel_without_confirm_stop_node(&node_handle);
@@ -119,7 +118,7 @@ mod chain_sync_test {
     #[test]
     #[file_serial]
     fn test_force_close_is_detected_offline_node_unconfirmed_channel() {
-        let node_handle = NodeHandle::new_with_lsp_setup();
+        let node_handle = NodeHandle::new_with_lsp_setup(true);
 
         let tx_id = start_node_open_channel_without_confirm_stop_node(&node_handle);
 

--- a/tests/chain_sync_test.rs
+++ b/tests/chain_sync_test.rs
@@ -15,7 +15,6 @@ mod chain_sync_test {
     const N_RETRIES: u8 = 10;
 
     #[test]
-    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
     #[file_serial]
     fn test_react_to_events() {
         let node_handle = NodeHandle::new_with_lsp_setup();

--- a/tests/chain_sync_test.rs
+++ b/tests/chain_sync_test.rs
@@ -15,7 +15,7 @@ mod chain_sync_test {
     const N_RETRIES: u8 = 10;
 
     #[test]
-    #[file_serial]
+    #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn test_react_to_events() {
         let node_handle = NodeHandle::new_with_lsp_setup(true);
         let node = node_handle.start().unwrap();
@@ -75,7 +75,7 @@ mod chain_sync_test {
     }
 
     #[test]
-    #[file_serial]
+    #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn test_react_to_events_with_offline_node() {
         let node_handle = NodeHandle::new_with_lsp_setup(true);
 
@@ -116,7 +116,7 @@ mod chain_sync_test {
     }
 
     #[test]
-    #[file_serial]
+    #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn test_force_close_is_detected_offline_node_unconfirmed_channel() {
         let node_handle = NodeHandle::new_with_lsp_setup(true);
 

--- a/tests/node_info_test.rs
+++ b/tests/node_info_test.rs
@@ -8,6 +8,8 @@ mod node_info_test {
     use bitcoin::secp256k1::PublicKey;
 
     #[test]
+    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
+    #[file_serial]
     fn test_get_node_info() {
         setup::nigiri::start();
         let node = NodeHandle::new().start().unwrap();

--- a/tests/node_info_test.rs
+++ b/tests/node_info_test.rs
@@ -10,7 +10,6 @@ mod node_info_test {
     use crate::setup::NodeHandle;
 
     #[test]
-    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
     #[file_parallel]
     fn test_get_node_info() {
         setup::nigiri::start();

--- a/tests/node_info_test.rs
+++ b/tests/node_info_test.rs
@@ -2,8 +2,6 @@ mod setup;
 
 #[cfg(feature = "nigiri")]
 mod node_info_test {
-    use super::*;
-
     use bitcoin::secp256k1::PublicKey;
     use serial_test::file_parallel;
 
@@ -12,8 +10,9 @@ mod node_info_test {
     #[test]
     #[file_parallel]
     fn test_get_node_info() {
-        setup::nigiri::start();
-        let node = NodeHandle::new().start().unwrap();
+        let node = NodeHandle::new_with_lsp_setup(false);
+        let node = node.start().unwrap();
+
         let node_info = node.get_node_info();
 
         assert!(

--- a/tests/node_info_test.rs
+++ b/tests/node_info_test.rs
@@ -8,7 +8,7 @@ mod node_info_test {
     use crate::setup::NodeHandle;
 
     #[test]
-    #[file_parallel]
+    #[file_parallel(key, "/tmp/3l-int-tests-lock")]
     fn test_get_node_info() {
         let node = NodeHandle::new_with_lsp_setup(false);
         let node = node.start().unwrap();

--- a/tests/node_info_test.rs
+++ b/tests/node_info_test.rs
@@ -4,12 +4,14 @@ mod setup;
 mod node_info_test {
     use super::*;
 
-    use crate::setup::NodeHandle;
     use bitcoin::secp256k1::PublicKey;
+    use serial_test::file_parallel;
+
+    use crate::setup::NodeHandle;
 
     #[test]
     // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
-    #[file_serial]
+    #[file_parallel]
     fn test_get_node_info() {
         setup::nigiri::start();
         let node = NodeHandle::new().start().unwrap();

--- a/tests/p2p_connection_test.rs
+++ b/tests/p2p_connection_test.rs
@@ -7,6 +7,7 @@ mod setup;
 mod p2p_connection_test {
     use super::*;
     use bitcoin::hashes::hex::ToHex;
+    use serial_test::file_serial;
     use std::thread::sleep;
     use std::time::Duration;
 
@@ -14,6 +15,8 @@ mod p2p_connection_test {
     use crate::setup::NodeHandle;
 
     #[test]
+    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
+    #[file_serial]
     fn test_p2p_connection() {
         setup::nigiri::start();
 

--- a/tests/p2p_connection_test.rs
+++ b/tests/p2p_connection_test.rs
@@ -16,7 +16,7 @@ mod p2p_connection_test {
     use crate::setup::NodeHandle;
 
     #[test]
-    #[file_parallel]
+    #[file_parallel(key, "/tmp/3l-int-tests-lock")]
     fn test_p2p_connection() {
         let node = NodeHandle::new_with_lsp_setup(false);
         let node = node.start().unwrap();
@@ -28,7 +28,7 @@ mod p2p_connection_test {
     }
 
     #[test]
-    #[file_serial]
+    #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn test_p2p_connection_with_unreliable_lsp() {
         let node = NodeHandle::new_with_lsp_setup(false);
         let node = node.start().unwrap();

--- a/tests/p2p_connection_test.rs
+++ b/tests/p2p_connection_test.rs
@@ -17,9 +17,8 @@ mod p2p_connection_test {
     #[test]
     #[file_serial]
     fn test_p2p_connection() {
-        setup::nigiri::start();
-
-        let node = NodeHandle::new().start().unwrap();
+        let node = NodeHandle::new_with_lsp_setup(false);
+        let node = node.start().unwrap();
 
         // Test successful p2p connection.
         {

--- a/tests/p2p_connection_test.rs
+++ b/tests/p2p_connection_test.rs
@@ -15,7 +15,6 @@ mod p2p_connection_test {
     use crate::setup::NodeHandle;
 
     #[test]
-    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
     #[file_serial]
     fn test_p2p_connection() {
         setup::nigiri::start();

--- a/tests/p2p_connection_test.rs
+++ b/tests/p2p_connection_test.rs
@@ -7,6 +7,7 @@ mod setup;
 mod p2p_connection_test {
     use super::*;
     use bitcoin::hashes::hex::ToHex;
+    use serial_test::file_parallel;
     use serial_test::file_serial;
     use std::thread::sleep;
     use std::time::Duration;
@@ -15,18 +16,22 @@ mod p2p_connection_test {
     use crate::setup::NodeHandle;
 
     #[test]
-    #[file_serial]
+    #[file_parallel]
     fn test_p2p_connection() {
         let node = NodeHandle::new_with_lsp_setup(false);
         let node = node.start().unwrap();
 
-        // Test successful p2p connection.
-        {
-            sleep(Duration::from_millis(100));
-            assert_eq!(node.get_node_info().num_peers, 1);
-            let peers = setup::nigiri::list_peers(NodeInstance::LspdLnd).unwrap();
-            assert!(peers.contains(&node.get_node_info().node_pubkey.to_hex()));
-        }
+        sleep(Duration::from_millis(100));
+        assert_eq!(node.get_node_info().num_peers, 1);
+        let peers = setup::nigiri::list_peers(NodeInstance::LspdLnd).unwrap();
+        assert!(peers.contains(&node.get_node_info().node_pubkey.to_hex()));
+    }
+
+    #[test]
+    #[file_serial]
+    fn test_p2p_connection_with_unreliable_lsp() {
+        let node = NodeHandle::new_with_lsp_setup(false);
+        let node = node.start().unwrap();
 
         // Test disconnect when LSP is down.
         {

--- a/tests/rapid_gossip_sync_test.rs
+++ b/tests/rapid_gossip_sync_test.rs
@@ -22,7 +22,6 @@ mod zero_conf_test {
     const LSPD_LND_PORT: u16 = 9739;
 
     #[test]
-    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
     #[file_serial]
     fn test_update_from_0_and_partial_update() {
         let node_handle = NodeHandle::new_with_lsp_rgs_setup();

--- a/tests/rapid_gossip_sync_test.rs
+++ b/tests/rapid_gossip_sync_test.rs
@@ -22,7 +22,7 @@ mod zero_conf_test {
     const LSPD_LND_PORT: u16 = 9739;
 
     #[test]
-    #[file_serial]
+    #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn test_update_from_0_and_partial_update() {
         let node_handle = NodeHandle::new_with_lsp_rgs_setup();
 

--- a/tests/rapid_gossip_sync_test.rs
+++ b/tests/rapid_gossip_sync_test.rs
@@ -6,8 +6,8 @@ mod zero_conf_test {
     use crate::setup::{nigiri, NodeHandle};
     use crate::try_cmd_repeatedly;
     use bitcoin::hashes::hex::ToHex;
-    use serial_test::file_serial;
     use log::info;
+    use serial_test::file_serial;
     use std::thread::sleep;
     use std::time::Duration;
     use uniffi_lipalightninglib::LightningNode;

--- a/tests/rapid_gossip_sync_test.rs
+++ b/tests/rapid_gossip_sync_test.rs
@@ -1,14 +1,12 @@
 mod setup;
 
-// Caution: Run these tests sequentially, otherwise they will corrupt each other
-//          because they are manipulating their environment:
-//          cargo test --features nigiri -- --test-threads 1
 #[cfg(feature = "nigiri")]
 mod zero_conf_test {
     use crate::setup::nigiri::{wait_for_new_channel_to_confirm, NodeInstance};
     use crate::setup::{nigiri, NodeHandle};
     use crate::try_cmd_repeatedly;
     use bitcoin::hashes::hex::ToHex;
+    use serial_test::file_serial;
     use log::info;
     use std::thread::sleep;
     use std::time::Duration;
@@ -24,6 +22,8 @@ mod zero_conf_test {
     const LSPD_LND_PORT: u16 = 9739;
 
     #[test]
+    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
+    #[file_serial]
     fn test_update_from_0_and_partial_update() {
         let node_handle = NodeHandle::new_with_lsp_rgs_setup();
 

--- a/tests/receiving_payments_test.rs
+++ b/tests/receiving_payments_test.rs
@@ -31,7 +31,7 @@ mod receiving_payments_test {
     fn test_multiple_receive_scenarios() {
         // Test receiving an invoice on a node that does not have any channel yet
         // resp, the channel opening is part of the payment process.
-        let node_handle = NodeHandle::new_with_lsp_setup();
+        let node_handle = NodeHandle::new_with_lsp_setup(true);
 
         {
             let node = node_handle.start().unwrap();
@@ -124,7 +124,7 @@ mod receiving_payments_test {
     #[test]
     #[file_serial]
     fn receive_multiple_payments_for_same_invoice() {
-        let node_handle = NodeHandle::new_with_lsp_setup();
+        let node_handle = NodeHandle::new_with_lsp_setup(false);
 
         let node = node_handle.start().unwrap();
         let lipa_node_id = node.get_node_info().node_pubkey.to_hex();

--- a/tests/receiving_payments_test.rs
+++ b/tests/receiving_payments_test.rs
@@ -27,7 +27,6 @@ mod receiving_payments_test {
     const LSPD_LND_PORT: u16 = 9739;
 
     #[test]
-    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
     #[file_serial]
     fn test_multiple_receive_scenarios() {
         // Test receiving an invoice on a node that does not have any channel yet
@@ -123,7 +122,6 @@ mod receiving_payments_test {
     // This also tests that payments with a hop work and as such, routing hints are being correctly
     // included in the created invoices
     #[test]
-    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
     #[file_serial]
     fn receive_multiple_payments_for_same_invoice() {
         let node_handle = NodeHandle::new_with_lsp_setup();

--- a/tests/receiving_payments_test.rs
+++ b/tests/receiving_payments_test.rs
@@ -1,11 +1,9 @@
 mod setup;
 
-// Caution: Run these tests sequentially, otherwise they will corrupt each other,
-// because they are manipulating their environment:
-// cargo test --features nigiri -- --test-threads 1
 #[cfg(feature = "nigiri")]
 mod receiving_payments_test {
     use bitcoin::hashes::hex::ToHex;
+    use serial_test::file_serial;
     use log::info;
     use std::thread::sleep;
     use std::time::Duration;
@@ -29,6 +27,8 @@ mod receiving_payments_test {
     const LSPD_LND_PORT: u16 = 9739;
 
     #[test]
+    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
+    #[file_serial]
     fn test_multiple_receive_scenarios() {
         // Test receiving an invoice on a node that does not have any channel yet
         // resp, the channel opening is part of the payment process.
@@ -120,9 +120,11 @@ mod receiving_payments_test {
         }
     }
 
-    #[test]
     // This also tests that payments with a hop work and as such, routing hints are being correctly
     // included in the created invoices
+    #[test]
+    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
+    #[file_serial]
     fn receive_multiple_payments_for_same_invoice() {
         let node_handle = NodeHandle::new_with_lsp_setup();
 

--- a/tests/receiving_payments_test.rs
+++ b/tests/receiving_payments_test.rs
@@ -3,8 +3,8 @@ mod setup;
 #[cfg(feature = "nigiri")]
 mod receiving_payments_test {
     use bitcoin::hashes::hex::ToHex;
-    use serial_test::file_serial;
     use log::info;
+    use serial_test::file_serial;
     use std::thread::sleep;
     use std::time::Duration;
     use uniffi_lipalightninglib::LightningNode;

--- a/tests/receiving_payments_test.rs
+++ b/tests/receiving_payments_test.rs
@@ -27,7 +27,7 @@ mod receiving_payments_test {
     const LSPD_LND_PORT: u16 = 9739;
 
     #[test]
-    #[file_serial]
+    #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn test_multiple_receive_scenarios() {
         // Test receiving an invoice on a node that does not have any channel yet
         // resp, the channel opening is part of the payment process.
@@ -122,7 +122,7 @@ mod receiving_payments_test {
     // This also tests that payments with a hop work and as such, routing hints are being correctly
     // included in the created invoices
     #[test]
-    #[file_serial]
+    #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn receive_multiple_payments_for_same_invoice() {
         let node_handle = NodeHandle::new_with_lsp_setup(false);
 

--- a/tests/receiving_payments_test.rs
+++ b/tests/receiving_payments_test.rs
@@ -9,7 +9,7 @@ mod receiving_payments_test {
     use std::time::Duration;
     use uniffi_lipalightninglib::LightningNode;
 
-    use crate::setup::nigiri::{wait_for_new_channel_to_confirm, NodeInstance};
+    use crate::setup::nigiri::NodeInstance;
     use crate::setup::{nigiri, NodeHandle};
     use crate::try_cmd_repeatedly;
 
@@ -46,7 +46,7 @@ mod receiving_payments_test {
             nigiri::lnd_node_open_pub_channel(NodeInstance::NigiriLnd, &lspd_node_id, false)
                 .unwrap();
             try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 10);
-            wait_for_new_channel_to_confirm(NodeInstance::NigiriLnd, &lspd_node_id);
+            nigiri::wait_for_new_channel_to_confirm(NodeInstance::NigiriLnd, &lspd_node_id);
 
             run_jit_channel_open_flow(
                 &node,
@@ -142,9 +142,9 @@ mod receiving_payments_test {
         nigiri::lnd_node_open_channel(NodeInstance::NigiriLnd, &lspd_node_id, false).unwrap();
         nigiri::cln_node_open_pub_channel(NodeInstance::NigiriCln, &lspd_node_id).unwrap();
         try_cmd_repeatedly!(nigiri::mine_blocks, N_RETRIES, HALF_SEC, 10);
-        wait_for_new_channel_to_confirm(NodeInstance::LspdLnd, &lipa_node_id);
-        wait_for_new_channel_to_confirm(NodeInstance::NigiriLnd, &lspd_node_id);
-        wait_for_new_channel_to_confirm(NodeInstance::NigiriCln, &lspd_node_id);
+        nigiri::wait_for_new_channel_to_confirm(NodeInstance::LspdLnd, &lipa_node_id);
+        nigiri::wait_for_new_channel_to_confirm(NodeInstance::NigiriLnd, &lspd_node_id);
+        nigiri::wait_for_new_channel_to_confirm(NodeInstance::NigiriCln, &lspd_node_id);
 
         assert_channel_ready(&node, TWENTY_K_SATS * 3);
         let invoice = issue_invoice(&node, TWENTY_K_SATS);

--- a/tests/sending_payments_test.rs
+++ b/tests/sending_payments_test.rs
@@ -15,7 +15,7 @@ mod sending_payments_test {
     const PAYMENT_AMOUNT: u64 = 1_000_000;
 
     #[test]
-    #[file_serial]
+    #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn pay_invoice_direct_peer_test_and_invoice_decoding_test() {
         let node = nigiri::initiate_node_with_channel(LspdLnd);
 

--- a/tests/sending_payments_test.rs
+++ b/tests/sending_payments_test.rs
@@ -15,7 +15,6 @@ mod sending_payments_test {
     const PAYMENT_AMOUNT: u64 = 1_000_000;
 
     #[test]
-    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
     #[file_serial]
     fn pay_invoice_direct_peer_test_and_invoice_decoding_test() {
         let node = nigiri::initiate_node_with_channel(LspdLnd);

--- a/tests/sending_payments_test.rs
+++ b/tests/sending_payments_test.rs
@@ -1,10 +1,8 @@
 mod setup;
 
-// Caution: Run these tests sequentially, otherwise they will corrupt each other,
-//      because they are manipulating their environment:
-//      cargo test --features nigiri -- --test-threads 1
 #[cfg(feature = "nigiri")]
 mod sending_payments_test {
+    use serial_test::file_serial;
     use std::thread::sleep;
     use std::time::{Duration, UNIX_EPOCH};
     use uniffi_lipalightninglib::{InvoiceDetails, LightningNode};
@@ -17,6 +15,8 @@ mod sending_payments_test {
     const PAYMENT_AMOUNT: u64 = 1_000_000;
 
     #[test]
+    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
+    #[file_serial]
     fn pay_invoice_direct_peer_test_and_invoice_decoding_test() {
         let node = nigiri::initiate_node_with_channel(LspdLnd);
 

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -269,18 +269,25 @@ pub mod nigiri {
 
     pub fn wait_for_sync(node: NodeInstance) {
         for _ in 0..20 {
-            debug!("{:?} is NOT synced yet, waiting...", node);
-            sleep(Duration::from_millis(500));
-
-            if let Ok(info) = query_node_info(node) {
-                if info.synced {
-                    debug!("{:?} is synced", node);
-                    return;
-                }
+            if is_node_synced(node) {
+                return;
             }
+            sleep(Duration::from_millis(500));
         }
 
         panic!("Failed to start {:?}. Not synced after 5 sec.", node);
+    }
+
+    pub fn is_node_synced(node: NodeInstance) -> bool {
+        if let Ok(info) = query_node_info(node) {
+            if info.synced {
+                debug!("{:?} is synced", node);
+                return true;
+            }
+        }
+
+        debug!("{:?} is NOT synced yet, waiting...", node);
+        false
     }
 
     fn wait_for_esplora() {

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -486,7 +486,10 @@ pub mod nigiri {
 
         let output = exec(cmd.as_slice());
         if !output.status.success() {
-            return Err(produce_cmd_err_msg(&cmd, output));
+            let err_msg = String::from_utf8(output.stderr.clone()).unwrap();
+            if !err_msg.contains("already connected to peer") {
+                return Err(produce_cmd_err_msg(&cmd, output));
+            }
         }
 
         Ok(())

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -288,7 +288,7 @@ pub mod nigiri {
             sleep(Duration::from_millis(500));
         }
 
-        panic!("Failed to start {:?}. Not synced after 5 sec.", node);
+        panic!("Failed to start {:?}. Not synced after 10 sec.", node);
     }
 
     pub fn is_node_synced(node: NodeInstance) -> bool {

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -246,6 +246,13 @@ pub mod nigiri {
         wait_for_sync(NodeInstance::LspdLnd);
     }
 
+    pub fn ensure_lspd_running() {
+        if !is_node_synced(NodeInstance::LspdLnd) {
+            start_lspd();
+            wait_for_healthy_lspd();
+        }
+    }
+
     pub fn stop_rgs() {
         debug!("RGS server stopping ...");
         exec_in_dir(&["docker-compose", "down"], "rgs");

--- a/tests/zero_conf_test.rs
+++ b/tests/zero_conf_test.rs
@@ -9,7 +9,7 @@ mod zero_conf_test {
     use crate::setup::{nigiri, NodeHandle};
 
     #[test]
-    #[file_serial]
+    #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn test_zero_conf_channel_is_usable_without_confirmations() {
         let node_handle = NodeHandle::new_with_lsp_setup(true);
 

--- a/tests/zero_conf_test.rs
+++ b/tests/zero_conf_test.rs
@@ -1,16 +1,16 @@
 mod setup;
 
-// Caution: Run these tests sequentially, otherwise they will corrupt each other,
-// because they are manipulating their environment:
-// cargo test --features nigiri -- --test-threads 1
 #[cfg(feature = "nigiri")]
 mod zero_conf_test {
     use bitcoin::hashes::hex::ToHex;
+    use serial_test::file_serial;
 
     use crate::setup::nigiri::{wait_for_new_channel_to_confirm, NodeInstance};
     use crate::setup::{nigiri, NodeHandle};
 
     #[test]
+    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
+    #[file_serial]
     fn test_zero_conf_channel_is_usable_without_confirmations() {
         let node_handle = NodeHandle::new_with_lsp_setup();
 

--- a/tests/zero_conf_test.rs
+++ b/tests/zero_conf_test.rs
@@ -11,7 +11,7 @@ mod zero_conf_test {
     #[test]
     #[file_serial]
     fn test_zero_conf_channel_is_usable_without_confirmations() {
-        let node_handle = NodeHandle::new_with_lsp_setup();
+        let node_handle = NodeHandle::new_with_lsp_setup(true);
 
         let node = node_handle.start().unwrap();
         let node_id = node.get_node_info().node_pubkey.to_hex();

--- a/tests/zero_conf_test.rs
+++ b/tests/zero_conf_test.rs
@@ -9,7 +9,6 @@ mod zero_conf_test {
     use crate::setup::{nigiri, NodeHandle};
 
     #[test]
-    // Run test sequentially, to not corrupt each tests, because it is manipulating their environment
     #[file_serial]
     fn test_zero_conf_channel_is_usable_without_confirmations() {
         let node_handle = NodeHandle::new_with_lsp_setup();


### PR DESCRIPTION
- Don't run the entire integration test suite in one thread only (sequentially), but explicitly run test cases sequentially that require it. Tests that do not manipulate the environment can be run in parallel (with each other; Still not in parallel to the ones that manipulate the environment)
- Streamline some code instances (refactoring)
- Only reset the environment when necessary
- Significantly faster build times by caching the compiled artifacts of the dependencies (safes about 3.5 minutes per build job if a cache is available)

Integration test parallelization explained:
- An integration test that's `#[file_serial]` is guaranteed to run sequentially
- An integration test that's `#[file_parallel]` runs in parallel with other tests, however not together with tests that are marked  `#[file_serial]`
- An integration test that has no such annotation runs in parallel with other tests, even with the ones tagged as running sequentially