### PR TITLE
Fix double task execution

### DIFF
--- a/src/async_runtime.rs
+++ b/src/async_runtime.rs
@@ -59,13 +59,13 @@ impl Handle {
             let mut interval = time::interval(interval);
             interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
             loop {
-                func().await;
                 tokio::select! {
                     _ = stop_receiver.recv() => {
                         break;
                     },
                     _ = interval.tick() => {},
                 }
+                func().await;
             }
             drop(status_sender);
         });


### PR DESCRIPTION
```rust
interval.tick().await;
// approximately 0ms have elapsed. The first tick completes immediately.
```

https://docs.rs/tokio/latest/tokio/time/struct.Interval.html#method.tick