### PR TITLE
Unify test targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,10 @@ test:
 	cargo test --lib -- $(TEST)
 
 .PHONY: integrationtests
-integrationtests: TEST = *
+integrationtests: FILE = *
+integrationtests: TEST = ''
 integrationtests:
-	cargo test --features nigiri --test '$(TEST)' -- --test-threads 1
+	cargo test --features nigiri --test '$(FILE)' -- --test-threads 1 $(TEST)
 
 .PHONY: testall
 testall: test integrationtests


### PR DESCRIPTION
- `make test TEST=encryption` will run unittests having `encryption` in the name
- `make integrationtests TEST=p2p` will run integration tests having `p2p` in the name
- `make integrationtests FILE=receiving_payments_test` will run all integration tests in `receiving_payments_test.rs` file
- `make integrationtests FILE=receiving_payments_test TEST=payments_for_same_invoice` will run integration tests in `receiving_payments_test.rs` file having `payments_for_same_invoice` in the name
