### PR TITLE
Separate starting the node from starting the environment in int tests

### DIFF
--- a/eel/tests/chain_sync_test.rs
+++ b/eel/tests/chain_sync_test.rs
@@ -17,8 +17,9 @@ mod chain_sync_test {
     #[test]
     #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn test_react_to_events() {
-        let node_handle = NodeHandle::new_with_lsp_setup(true);
-        let node = node_handle.start().unwrap();
+        nigiri::setup_environment_with_lsp();
+
+        let node = NodeHandle::new().start().unwrap();
         let node_id = node.get_node_info().node_pubkey.to_hex();
 
         let tx_id = nigiri::lnd_node_open_channel(NodeInstance::LspdLnd, &node_id, false).unwrap();
@@ -77,7 +78,9 @@ mod chain_sync_test {
     #[test]
     #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn test_react_to_events_with_offline_node() {
-        let node_handle = NodeHandle::new_with_lsp_setup(true);
+        nigiri::setup_environment_with_lsp();
+
+        let node_handle = NodeHandle::new();
 
         // test channel is confirmed only after 6 confirmations with offline node
         let tx_id = start_node_open_channel_without_confirm_stop_node(&node_handle);
@@ -118,7 +121,8 @@ mod chain_sync_test {
     #[test]
     #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn test_force_close_is_detected_offline_node_unconfirmed_channel() {
-        let node_handle = NodeHandle::new_with_lsp_setup(true);
+        nigiri::setup_environment_with_lsp();
+        let node_handle = NodeHandle::new();
 
         let tx_id = start_node_open_channel_without_confirm_stop_node(&node_handle);
 

--- a/eel/tests/node_info_test.rs
+++ b/eel/tests/node_info_test.rs
@@ -5,14 +5,14 @@ mod node_info_test {
     use bitcoin::secp256k1::PublicKey;
     use serial_test::file_parallel;
 
-    use crate::setup::NodeHandle;
+    use crate::setup::{nigiri, NodeHandle};
 
     #[test]
     #[file_parallel(key, "/tmp/3l-int-tests-lock")]
     fn test_get_node_info() {
-        let node = NodeHandle::new_with_lsp_setup(false);
-        let node = node.start().unwrap();
+        nigiri::setup_environment_with_lsp();
 
+        let node = NodeHandle::new().start().unwrap();
         let node_info = node.get_node_info();
 
         assert!(

--- a/eel/tests/p2p_connection_test.rs
+++ b/eel/tests/p2p_connection_test.rs
@@ -13,13 +13,14 @@ mod p2p_connection_test {
     use std::time::Duration;
 
     use crate::setup::nigiri::NodeInstance;
-    use crate::setup::NodeHandle;
+    use crate::setup::{nigiri, NodeHandle};
 
     #[test]
     #[file_parallel(key, "/tmp/3l-int-tests-lock")]
     fn test_p2p_connection() {
-        let node = NodeHandle::new_with_lsp_setup(false);
-        let node = node.start().unwrap();
+        nigiri::ensure_nigiri_running();
+        nigiri::ensure_lspd_running();
+        let node = NodeHandle::new().start().unwrap();
 
         sleep(Duration::from_millis(100));
         assert_eq!(node.get_node_info().num_peers, 1);
@@ -30,8 +31,9 @@ mod p2p_connection_test {
     #[test]
     #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn test_p2p_connection_with_unreliable_lsp() {
-        let node = NodeHandle::new_with_lsp_setup(false);
-        let node = node.start().unwrap();
+        nigiri::ensure_nigiri_running();
+        nigiri::ensure_lspd_running();
+        let node = NodeHandle::new().start().unwrap();
 
         // Test disconnect when LSP is down.
         {

--- a/eel/tests/p2p_connection_test.rs
+++ b/eel/tests/p2p_connection_test.rs
@@ -18,7 +18,6 @@ mod p2p_connection_test {
     #[test]
     #[file_parallel(key, "/tmp/3l-int-tests-lock")]
     fn test_p2p_connection() {
-        nigiri::ensure_nigiri_running();
         nigiri::ensure_lspd_running();
         let node = NodeHandle::new().start().unwrap();
 
@@ -31,7 +30,6 @@ mod p2p_connection_test {
     #[test]
     #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn test_p2p_connection_with_unreliable_lsp() {
-        nigiri::ensure_nigiri_running();
         nigiri::ensure_lspd_running();
         let node = NodeHandle::new().start().unwrap();
 

--- a/eel/tests/rapid_gossip_sync_test.rs
+++ b/eel/tests/rapid_gossip_sync_test.rs
@@ -24,7 +24,8 @@ mod rapid_gossip_sync_test {
     #[test]
     #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn test_update_from_0_and_partial_update() {
-        let node_handle = NodeHandle::new_with_lsp_rgs_setup();
+        nigiri::setup_environment_with_lsp_rgs();
+        let node_handle = NodeHandle::new();
 
         let lspd_node_id = nigiri::query_node_info(NodeInstance::LspdLnd)
             .unwrap()

--- a/eel/tests/receiving_payments_test.rs
+++ b/eel/tests/receiving_payments_test.rs
@@ -31,7 +31,8 @@ mod receiving_payments_test {
     fn test_multiple_receive_scenarios() {
         // Test receiving an invoice on a node that does not have any channel yet
         // resp, the channel opening is part of the payment process.
-        let node_handle = NodeHandle::new_with_lsp_setup(true);
+        nigiri::setup_environment_with_lsp();
+        let node_handle = NodeHandle::new();
 
         {
             let node = node_handle.start().unwrap();
@@ -124,9 +125,10 @@ mod receiving_payments_test {
     #[test]
     #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn receive_multiple_payments_for_same_invoice() {
-        let node_handle = NodeHandle::new_with_lsp_setup(false);
+        nigiri::ensure_nigiri_running();
+        nigiri::ensure_lspd_running();
 
-        let node = node_handle.start().unwrap();
+        let node = NodeHandle::new().start().unwrap();
         let lipa_node_id = node.get_node_info().node_pubkey.to_hex();
         assert_eq!(node.get_node_info().num_peers, 1);
 

--- a/eel/tests/receiving_payments_test.rs
+++ b/eel/tests/receiving_payments_test.rs
@@ -125,7 +125,6 @@ mod receiving_payments_test {
     #[test]
     #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn receive_multiple_payments_for_same_invoice() {
-        nigiri::ensure_nigiri_running();
         nigiri::ensure_lspd_running();
 
         let node = NodeHandle::new().start().unwrap();

--- a/eel/tests/setup/mod.rs
+++ b/eel/tests/setup/mod.rs
@@ -158,7 +158,6 @@ pub mod nigiri {
         pub synced: bool,
     }
 
-    #[cfg(feature = "nigiri")]
     pub fn setup_environment_with_lsp() {
         start_all_clean();
 

--- a/eel/tests/setup/mod.rs
+++ b/eel/tests/setup/mod.rs
@@ -96,35 +96,6 @@ impl NodeHandle {
         NodeHandle { config, storage }
     }
 
-    #[cfg(feature = "nigiri")]
-    pub fn new_with_lsp_setup(reset: bool) -> NodeHandle {
-        if reset || !nigiri::is_node_synced(NodeInstance::NigiriLnd) {
-            nigiri::start();
-
-            // to open multiple channels in the same block, multiple UTXOs are required
-            for _ in 0..10 {
-                nigiri::fund_node(NodeInstance::LspdLnd, 0.5);
-                nigiri::fund_node(NodeInstance::NigiriLnd, 0.5);
-                nigiri::fund_node(NodeInstance::NigiriCln, 0.5);
-            }
-        } else {
-            nigiri::ensure_lspd_running();
-        }
-
-        Self::new()
-    }
-
-    #[cfg(feature = "nigiri")]
-    pub fn new_with_lsp_rgs_setup() -> NodeHandle {
-        let handle = Self::new_with_lsp_setup(true);
-
-        node_connect_to_rgs_cln(NodeInstance::LspdLnd);
-        node_connect_to_rgs_cln(NodeInstance::NigiriLnd);
-        node_connect_to_rgs_cln(NodeInstance::NigiriCln);
-
-        handle
-    }
-
     pub fn start(&self) -> LipaResult<LightningNode> {
         let lsp_address = "http://127.0.0.1:6666".to_string();
         let lsp_auth_token =
@@ -187,7 +158,27 @@ pub mod nigiri {
         pub synced: bool,
     }
 
-    pub fn start() {
+    #[cfg(feature = "nigiri")]
+    pub fn setup_environment_with_lsp() {
+        start_all_clean();
+
+        // to open multiple channels in the same block, multiple UTXOs are required
+        for _ in 0..10 {
+            fund_node(NodeInstance::LspdLnd, 0.5);
+            fund_node(NodeInstance::NigiriLnd, 0.5);
+            fund_node(NodeInstance::NigiriCln, 0.5);
+        }
+    }
+
+    pub fn setup_environment_with_lsp_rgs() {
+        setup_environment_with_lsp();
+
+        node_connect_to_rgs_cln(NodeInstance::LspdLnd);
+        node_connect_to_rgs_cln(NodeInstance::NigiriLnd);
+        node_connect_to_rgs_cln(NodeInstance::NigiriCln);
+    }
+
+    pub fn start_all_clean() {
         INIT_LOGGER_ONCE.call_once(|| {
             SimpleLogger::init(simplelog::LevelFilter::Debug, simplelog::Config::default())
                 .unwrap();
@@ -246,6 +237,15 @@ pub mod nigiri {
 
     pub fn wait_for_healthy_lspd() {
         wait_for_sync(NodeInstance::LspdLnd);
+    }
+
+    pub fn ensure_nigiri_running() {
+        if is_node_synced(NodeInstance::NigiriLnd) {
+            debug!("Nigiri already running");
+        } else {
+            start_nigiri();
+            wait_for_healthy_nigiri();
+        }
     }
 
     pub fn ensure_lspd_running() {
@@ -773,9 +773,9 @@ pub mod nigiri {
     }
 
     pub fn initiate_node_with_channel(remote_node: NodeInstance) -> LightningNode {
-        let node_handle = NodeHandle::new_with_lsp_setup(true);
+        nigiri::setup_environment_with_lsp();
 
-        let node = node_handle.start().unwrap();
+        let node = NodeHandle::new().start().unwrap();
         let node_id = node.get_node_info().node_pubkey.to_hex();
 
         assert_eq!(node.get_node_info().num_peers, 1);
@@ -817,7 +817,7 @@ pub mod nigiri {
             retries += 1;
             if retries >= 220 {
                 panic!(
-                    "Failed to create channel between from {:?} to {}",
+                    "Failed to create channel from {:?} to {}",
                     node, target_node_id
                 );
             }

--- a/eel/tests/setup/mod.rs
+++ b/eel/tests/setup/mod.rs
@@ -249,6 +249,8 @@ pub mod nigiri {
     }
 
     pub fn ensure_lspd_running() {
+        ensure_nigiri_running();
+
         if is_node_synced(NodeInstance::LspdLnd) {
             debug!("LSPD already running");
         } else {

--- a/eel/tests/zero_conf_test.rs
+++ b/eel/tests/zero_conf_test.rs
@@ -11,9 +11,9 @@ mod zero_conf_test {
     #[test]
     #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn test_zero_conf_channel_is_usable_without_confirmations() {
-        let node_handle = NodeHandle::new_with_lsp_setup(true);
+        nigiri::setup_environment_with_lsp();
 
-        let node = node_handle.start().unwrap();
+        let node = NodeHandle::new().start().unwrap();
         let node_id = node.get_node_info().node_pubkey.to_hex();
 
         assert_eq!(node.get_node_info().num_peers, 1);


### PR DESCRIPTION
A better following of the single-responsibility principle allows us in this case to create a new node without restarting the entire environment in cases the latter isn't required.