### PR TITLE
Disable `cross` for iOS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,12 +61,10 @@ jobs:
           submodules: true
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.2.0
-      - name: Install Cross
-        run: cargo install cross --locked
       - name: Build target
         uses: actions-rs/cargo@v1
         with:
-          use-cross: true
+          use-cross: false
           command: build
           args: --target ${{ matrix.target }}
   build-android:

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -32,12 +32,10 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install Cross
-        run: cargo install cross --locked
       - name: Build target
         uses: actions-rs/cargo@v1
         with:
-          use-cross: true
+          use-cross: false
           command: build
           args: --release --target ${{ matrix.target }}
       - name: Upload library binaries


### PR DESCRIPTION
It isn't used in practice, and removing the option saves time by avoiding the cross install step.