### PR TITLE
Differ between fmt and fmt-check in Makefile

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -36,7 +36,7 @@ jobs:
           components: rustfmt
       - uses: actions/checkout@v3
       - name: Check code formatting
-        run: make fmt check-mod-test
+        run: make fmt-check check-mod-test
   clippy_check:
     name: Clippy check
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,11 @@ testall: test integrationtests
 
 .PHONY: fmt
 fmt:
+	cargo fmt
+	cargo fmt --manifest-path eel/Cargo.toml
+
+.PHONY: fmt-check
+fmt-check:
 	cargo fmt -- --check
 	cargo fmt --manifest-path eel/Cargo.toml -- --check
 
@@ -51,7 +56,7 @@ check-mod-test:
 
 # Quick tests to run before creating a PR.
 .PHONY: pr
-pr: fmt buildall test clippy check-mod-test
+pr: fmt-check buildall test clippy check-mod-test
 
 .PHONY: runnode
 runnode:

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ check-mod-test:
 
 # Quick tests to run before creating a PR.
 .PHONY: pr
-pr: fmt-check buildall test clippy check-mod-test
+pr: fmt buildall test clippy check-mod-test
 
 .PHONY: runnode
 runnode:


### PR DESCRIPTION
Since we have the `eel` lib living within the same project, you can not simply `cargo fmt` anymore, to fix your formatting in the entire repo.

After this PR is merged, you can:
- `make fmt`: Format all of your code
- `make fmt-check`: Check whether all of your code is formatted