### PR TITLE
Initial payment store setup

### DIFF
--- a/eel/Cargo.toml
+++ b/eel/Cargo.toml
@@ -30,7 +30,8 @@ secp256k1 = { version = "0.24.3", features = ["global-context"] }
 thiserror = "1.0.34"
 tokio = { version = "1.21.1", features = ["rt-multi-thread", "time", "sync"] }
 tonic = "0.8.3"
-rusqlite = { version = "0.28.0", features = ["bundled"] }
+rusqlite = { version = "0.28.0", features = ["bundled", "chrono"] }
+chrono = { version = "0.4.23", default-features = false }
 
 perro = { git = "https://github.com/getlipa/perro", tag = "v1.0.0" }
 

--- a/eel/Cargo.toml
+++ b/eel/Cargo.toml
@@ -30,6 +30,7 @@ secp256k1 = { version = "0.24.3", features = ["global-context"] }
 thiserror = "1.0.34"
 tokio = { version = "1.21.1", features = ["rt-multi-thread", "time", "sync"] }
 tonic = "0.8.3"
+rusqlite = { version = "0.28.0", features = ["bundled"] }
 
 perro = { git = "https://github.com/getlipa/perro", tag = "v1.0.0" }
 

--- a/eel/src/event_handler.rs
+++ b/eel/src/event_handler.rs
@@ -121,7 +121,7 @@ impl EventHandler for LipaEventHandler {
                             .payment_store
                             .lock()
                             .unwrap()
-                            .payment_succeeded(payment_hash.0.as_slice(), 0.0)
+                            .payment_succeeded(payment_hash.0.as_slice())
                             .is_err()
                         {
                             error!("Failed to persist in the payment db that the receiving payment with hash {:?} has succeeded", payment_hash);

--- a/eel/src/event_handler.rs
+++ b/eel/src/event_handler.rs
@@ -67,6 +67,18 @@ impl EventHandler for LipaEventHandler {
                             "Registered incoming invoice payment for {} msat with hash {:?}",
                             amount_msat, payment_hash
                         );
+                        if self
+                            .payment_store
+                            .lock()
+                            .unwrap()
+                            .fill_preimage(payment_hash.0.as_slice(), payment_preimage.0.as_slice())
+                            .is_err()
+                        {
+                            error!(
+                                "Failed to fill preimage in the payment db for payment hash {:?}",
+                                payment_hash
+                            );
+                        }
                         self.channel_manager.claim_funds(payment_preimage);
                     }
                     PaymentPurpose::InvoicePayment {

--- a/eel/src/invoice.rs
+++ b/eel/src/invoice.rs
@@ -122,15 +122,8 @@ pub(crate) async fn create_invoice(
         .sign(|_| Ok::<RecoverableSignature, ()>(signature))
         .map_to_permanent_failure("Failed to sign invoice")?;
 
-    // TODO: store fiat value
     payment_store
-        .new_incoming_payment(
-            &payment_hash,
-            amount_msat,
-            0.0,
-            lsp_fee,
-            &invoice.to_string(),
-        )
+        .new_incoming_payment(&payment_hash, amount_msat, lsp_fee, &invoice.to_string())
         .map_to_permanent_failure("Failed to store new payment in payment db")?;
 
     Ok(invoice)

--- a/eel/src/lib.rs
+++ b/eel/src/lib.rs
@@ -55,7 +55,7 @@ use crate::tx_broadcaster::TxBroadcaster;
 use crate::types::{ChainMonitor, ChannelManager, InvoicePayer, PeerManager, RapidGossipSync};
 use std::path::Path;
 
-use crate::payment_store::PaymentStore;
+use crate::payment_store::{Payment, PaymentStore};
 use bitcoin::blockdata::constants::genesis_block;
 pub use bitcoin::Network;
 use cipher::consts::U32;
@@ -432,6 +432,13 @@ impl LightningNode {
             }
         }
         Ok(())
+    }
+
+    pub fn get_latest_payments(&self, number_of_payments: u32) -> Result<Vec<Payment>> {
+        self.payment_store
+            .lock()
+            .unwrap()
+            .get_latest_payments(number_of_payments)
     }
 
     pub fn foreground(&self) {

--- a/eel/src/lib.rs
+++ b/eel/src/lib.rs
@@ -41,7 +41,7 @@ use crate::event_handler::LipaEventHandler;
 use crate::fee_estimator::FeeEstimator;
 use crate::filter::FilterImpl;
 use crate::interfaces::{EventHandler, RemoteStorage};
-use crate::invoice::create_raw_invoice;
+use crate::invoice::create_invoice;
 pub use crate::invoice::InvoiceDetails;
 use crate::keys_manager::init_keys_manager;
 use crate::logger::LightningLogger;
@@ -56,9 +56,7 @@ use crate::types::{ChainMonitor, ChannelManager, InvoicePayer, PeerManager, Rapi
 use std::path::Path;
 
 use crate::payment_store::PaymentStore;
-use bitcoin::bech32::ToBase32;
 use bitcoin::blockdata::constants::genesis_block;
-use bitcoin::secp256k1::ecdsa::RecoverableSignature;
 pub use bitcoin::Network;
 use cipher::consts::U32;
 use lightning::chain::channelmonitor::ChannelMonitor;
@@ -268,12 +266,20 @@ impl LightningNode {
         )));
         task_manager.lock().unwrap().restart(FOREGROUND_PERIODS);
 
+        let payment_store_path = Path::new(&config.local_persistence_path).join("payment_db.db3");
+        let payment_store_path = payment_store_path
+            .to_str()
+            .ok_or_invalid_input("Invalid local persistence path")?;
+
+        let payment_store = Mutex::new(PaymentStore::new(payment_store_path)?);
+
         // Step 15. Initialize an EventHandler
         let event_handler = Arc::new(LipaEventHandler::new(
             Arc::clone(&channel_manager),
             Arc::clone(&task_manager),
             user_event_handler,
-        ));
+            payment_store_path,
+        )?);
 
         // Step 16. Initialize the ProbabilisticScorer
         let scorer = Arc::new(Mutex::new(
@@ -316,13 +322,6 @@ impl LightningNode {
             logger,
             Some(scorer),
         );
-
-        let payment_store_path = Path::new(&config.local_persistence_path).join("payment_db.db3");
-        let payment_store = Mutex::new(PaymentStore::new(
-            payment_store_path
-                .to_str()
-                .ok_or_invalid_input("Invalid local persistence path")?,
-        )?);
 
         Ok(Self {
             network: config.network,
@@ -367,24 +366,15 @@ impl LightningNode {
             Network::Regtest => Currency::Regtest,
             Network::Signet => Currency::Signet,
         };
-        let raw_invoice = self.rt.handle().block_on(create_raw_invoice(
+        let signed_invoice = self.rt.handle().block_on(create_invoice(
             amount_msat,
             currency,
             description,
             &self.channel_manager,
             &self.lsp_client,
+            &self.keys_manager,
+            &mut self.payment_store.lock().unwrap(),
         ))?;
-        let signature = self
-            .keys_manager
-            .sign_invoice(
-                raw_invoice.hrp.to_string().as_bytes(),
-                &raw_invoice.data.to_base32(),
-                Recipient::Node,
-            )
-            .map_to_permanent_failure("Failed to sign invoice")?;
-        let signed_invoice = raw_invoice
-            .sign(|_| Ok::<RecoverableSignature, ()>(signature))
-            .map_to_permanent_failure("Failed to sign invoice")?;
         Ok(signed_invoice.to_string())
     }
 

--- a/eel/tests/setup/mod.rs
+++ b/eel/tests/setup/mod.rs
@@ -19,6 +19,8 @@ use std::thread::sleep;
 use std::time::Duration;
 use storage_mock::Storage;
 
+const LOCAL_PERSISTENCE_PATH: &str = ".3l_local_test";
+
 static INIT_LOGGER_ONCE: Once = Once::new();
 
 #[allow(dead_code)]
@@ -51,7 +53,8 @@ impl NodeHandle {
     pub fn new(storage_config: mocked_remote_storage::Config) -> Self {
         let storage = MockedRemoteStorage::new(Arc::new(Storage::new()), storage_config);
 
-        let _ = fs::remove_dir_all(".3l_local_test");
+        let _ = fs::remove_dir_all(LOCAL_PERSISTENCE_PATH);
+        fs::create_dir(LOCAL_PERSISTENCE_PATH).unwrap();
 
         let config = Config {
             network: Network::Regtest,
@@ -61,7 +64,7 @@ impl NodeHandle {
             lsp_url: "http://127.0.0.1:6666".to_string(),
             lsp_token: "iQUvOsdk4ognKshZB/CKN2vScksLhW8i13vTO+8SPvcyWJ+fHi8OLgUEvW1N3k2l"
                 .to_string(),
-            local_persistence_path: ".3l_local_test".to_string(),
+            local_persistence_path: LOCAL_PERSISTENCE_PATH.to_string(),
         };
 
         NodeHandle { config, storage }


### PR DESCRIPTION
Handles persisting new receiving payments (when invoice is created), filling the preimage when we learn about it, and marking a receiving payment as successful when the funds are claimed. 