### PR TITLE
Expose `get_latest_payments()`

### DIFF
--- a/eel/examples/node/cli.rs
+++ b/eel/examples/node/cli.rs
@@ -136,7 +136,7 @@ fn create_invoice<'a>(
         .map_err(|_| "amount should be an integer number".to_string())?;
     let description = words.collect::<Vec<_>>().join(" ");
     let invoice = node
-        .create_invoice(amount, description)
+        .create_invoice(amount, description, &[])
         .map_err(|e| e.to_string())?;
     println!("{}", invoice);
     Ok(())
@@ -183,7 +183,7 @@ fn pay_invoice<'a>(
         .next()
         .ok_or_else(|| "invoice is required".to_string())?;
 
-    match node.pay_invoice(invoice.to_string()) {
+    match node.pay_invoice(invoice.to_string(), &[]) {
         Ok(_) => {}
         Err(e) => return Err(e.to_string()),
     };

--- a/eel/examples/node/cli.rs
+++ b/eel/examples/node/cli.rs
@@ -136,7 +136,7 @@ fn create_invoice<'a>(
         .map_err(|_| "amount should be an integer number".to_string())?;
     let description = words.collect::<Vec<_>>().join(" ");
     let invoice = node
-        .create_invoice(amount, description, vec![])
+        .create_invoice(amount, description, String::new())
         .map_err(|e| e.to_string())?;
     println!("{}", invoice);
     Ok(())
@@ -183,7 +183,7 @@ fn pay_invoice<'a>(
         .next()
         .ok_or_else(|| "invoice is required".to_string())?;
 
-    match node.pay_invoice(invoice.to_string(), vec![]) {
+    match node.pay_invoice(invoice.to_string(), String::new()) {
         Ok(_) => {}
         Err(e) => return Err(e.to_string()),
     };

--- a/eel/examples/node/cli.rs
+++ b/eel/examples/node/cli.rs
@@ -200,11 +200,13 @@ fn list_payments(node: &LightningNode) -> Result<(), String> {
     println!("Total of {} payments\n", payments.len());
 
     for payment in payments {
-        let datetime: DateTime<Utc> = payment.latest_state_change_at.into();
+        let created_at: DateTime<Utc> = payment.created_at.into();
+        let latest_state_change_at: DateTime<Utc> = payment.latest_state_change_at.into();
         println!(
-            "{:?} payment with state changed at {}",
+            "{:?} payment with created at {} and with latest state change at {}",
             payment.payment_type,
-            datetime.format("%d/%m/%Y %T")
+            created_at.format("%d/%m/%Y %T"),
+            latest_state_change_at.format("%d/%m/%Y %T")
         );
         println!("      State:              {:?}", payment.payment_state);
         println!("      Amount msat:        {}", payment.amount_msat);

--- a/eel/examples/node/cli.rs
+++ b/eel/examples/node/cli.rs
@@ -136,7 +136,7 @@ fn create_invoice<'a>(
         .map_err(|_| "amount should be an integer number".to_string())?;
     let description = words.collect::<Vec<_>>().join(" ");
     let invoice = node
-        .create_invoice(amount, description, &[])
+        .create_invoice(amount, description, vec![])
         .map_err(|e| e.to_string())?;
     println!("{}", invoice);
     Ok(())
@@ -183,7 +183,7 @@ fn pay_invoice<'a>(
         .next()
         .ok_or_else(|| "invoice is required".to_string())?;
 
-    match node.pay_invoice(invoice.to_string(), &[]) {
+    match node.pay_invoice(invoice.to_string(), vec![]) {
         Ok(_) => {}
         Err(e) => return Err(e.to_string()),
     };

--- a/eel/examples/node/cli.rs
+++ b/eel/examples/node/cli.rs
@@ -200,7 +200,7 @@ fn list_payments(node: &LightningNode) -> Result<(), String> {
     println!("Total of {} payments\n", payments.len());
 
     for payment in payments {
-        let datetime: DateTime<Utc> = payment.timestamp.into();
+        let datetime: DateTime<Utc> = payment.latest_state_change_at.into();
         println!(
             "{:?} payment with state changed at {}",
             payment.payment_type,

--- a/eel/examples/node/cli.rs
+++ b/eel/examples/node/cli.rs
@@ -1,4 +1,3 @@
-use bitcoin::hashes::hex::ToHex;
 use bitcoin::secp256k1::PublicKey;
 use chrono::{DateTime, Utc};
 use std::io;
@@ -211,11 +210,8 @@ fn list_payments(node: &LightningNode) -> Result<(), String> {
         println!("      Amount msat:        {}", payment.amount_msat);
         println!("      Network fees msat:  {:?}", payment.network_fees_msat);
         println!("      LSP fees:           {:?}", payment.lsp_fees_msat);
-        println!("      Hash:               {}", payment.hash.to_hex());
-        println!(
-            "      Preimage:           {:?}",
-            payment.preimage.map(|p| p.to_hex())
-        );
+        println!("      Hash:               {}", payment.hash);
+        println!("      Preimage:           {:?}", payment.preimage);
         println!("      Description:        {}", payment.description);
         println!("      Invoice:            {}", payment.invoice);
     }

--- a/eel/src/invoice.rs
+++ b/eel/src/invoice.rs
@@ -30,7 +30,7 @@ pub(crate) struct CreateInvoiceParams {
     pub amount_msat: u64,
     pub currency: Currency,
     pub description: String,
-    pub metadata: Vec<u8>,
+    pub metadata: String,
 }
 
 pub(crate) async fn create_invoice(

--- a/eel/src/invoice.rs
+++ b/eel/src/invoice.rs
@@ -26,16 +26,22 @@ pub struct InvoiceDetails {
     pub expiry_interval: Duration,
 }
 
+pub(crate) struct CreateInvoiceParams {
+    pub amount_msat: u64,
+    pub currency: Currency,
+    pub description: String,
+    pub metadata: Vec<u8>,
+}
+
 pub(crate) async fn create_invoice(
-    amount_msat: u64,
-    currency: Currency,
-    description: String,
+    params: CreateInvoiceParams,
     channel_manager: &ChannelManager,
     lsp_client: &LspClient,
     keys_manager: &KeysManager,
     payment_store: &mut PaymentStore,
-    metadata: &[u8],
 ) -> Result<SignedRawInvoice> {
+    let amount_msat = params.amount_msat;
+
     // Do we need a new channel to receive this payment?
     let channels_info = get_channels_info(&channel_manager.list_channels());
     let needs_channel_opening = channels_info.inbound_capacity_msat < amount_msat;
@@ -96,8 +102,8 @@ pub(crate) async fn create_invoice(
 
     let payment_hash = sha256::Hash::from_slice(&payment_hash.0)
         .map_to_permanent_failure("Failed to convert payment hash")?;
-    let mut builder = InvoiceBuilder::new(currency)
-        .description(description.clone())
+    let mut builder = InvoiceBuilder::new(params.currency)
+        .description(params.description.clone())
         .payment_hash(payment_hash)
         .payment_secret(payment_secret)
         .payee_pub_key(payee_pubkey)
@@ -128,9 +134,9 @@ pub(crate) async fn create_invoice(
             &payment_hash,
             amount_msat,
             lsp_fee,
-            &description,
+            &params.description,
             &invoice.to_string(),
-            &metadata,
+            &params.metadata,
         )
         .map_to_permanent_failure("Failed to store new payment in payment db")?;
 

--- a/eel/src/invoice.rs
+++ b/eel/src/invoice.rs
@@ -34,6 +34,7 @@ pub(crate) async fn create_invoice(
     lsp_client: &LspClient,
     keys_manager: &KeysManager,
     payment_store: &mut PaymentStore,
+    metadata: &[u8],
 ) -> Result<SignedRawInvoice> {
     // Do we need a new channel to receive this payment?
     let channels_info = get_channels_info(&channel_manager.list_channels());
@@ -129,6 +130,7 @@ pub(crate) async fn create_invoice(
             lsp_fee,
             &description,
             &invoice.to_string(),
+            &metadata,
         )
         .map_to_permanent_failure("Failed to store new payment in payment db")?;
 

--- a/eel/src/lib.rs
+++ b/eel/src/lib.rs
@@ -364,7 +364,7 @@ impl LightningNode {
         &self,
         amount_msat: u64,
         description: String,
-        metadata: Vec<u8>,
+        metadata: String,
     ) -> Result<String> {
         let currency = match self.network {
             Network::Bitcoin => Currency::Bitcoin,
@@ -410,7 +410,7 @@ impl LightningNode {
         })
     }
 
-    pub fn pay_invoice(&self, invoice: String, metadata: Vec<u8>) -> Result<()> {
+    pub fn pay_invoice(&self, invoice: String, metadata: String) -> Result<()> {
         let invoice_struct = Self::parse_validate_invoice(self, &invoice)?;
 
         let amount_msat = invoice_struct

--- a/eel/src/lib.rs
+++ b/eel/src/lib.rs
@@ -9,6 +9,7 @@ pub mod keys_manager;
 pub mod lsp;
 pub mod node_info;
 pub mod p2p_networking;
+pub mod payment_store;
 pub mod secret;
 
 mod async_runtime;
@@ -22,7 +23,6 @@ mod filter;
 mod invoice;
 mod key_derivation;
 mod logger;
-mod payment_store;
 mod random;
 mod rapid_sync_client;
 mod storage_persister;

--- a/eel/src/payment_store.rs
+++ b/eel/src/payment_store.rs
@@ -34,7 +34,7 @@ pub struct Payment {
     pub preimage: Option<String>,
     pub network_fees_msat: Option<u64>,
     pub lsp_fees_msat: Option<u64>,
-    pub metadata: Vec<u8>,
+    pub metadata: String,
 }
 
 pub(crate) struct PaymentStore {
@@ -57,7 +57,7 @@ impl PaymentStore {
         lsp_fees_msat: u64,
         description: &str,
         invoice: &str,
-        metadata: &[u8],
+        metadata: &str,
     ) -> Result<()> {
         let tx = self
             .db_conn
@@ -97,7 +97,7 @@ impl PaymentStore {
         amount_msat: u64,
         description: &str,
         invoice: &str,
-        metadata: &[u8],
+        metadata: &str,
     ) -> Result<()> {
         let tx = self
             .db_conn
@@ -291,7 +291,7 @@ fn apply_migrations(db_conn: &Connection) -> Result<()> {
               preimage BLOB,
               network_fees_msat INTEGER,
               lsp_fees_msat INTEGER,
-              metadata BLOB
+              metadata TEXT
             );
             CREATE TABLE IF NOT EXISTS events (
               event_id INTEGER NOT NULL PRIMARY KEY,
@@ -343,7 +343,7 @@ mod tests {
         let lsp_fees_msat = 2_000_000;
         let description = String::from("Test description 1");
         let invoice = String::from("lnbcrt1m1p37fe7udqqpp5e2mktq6ykgp0e9uljdrakvcy06wcwtswgwe7yl6jmfry4dke2t2ssp5s3uja8xn7tpeuctc62xqua6slpj40jrwlkuwmluv48g86r888g7s9qrsgqnp4qfalfq06c807p3mlt4ggtufckg3nq79wnh96zjz748zmhl5vys3dgcqzysrzjqwp6qac7ttkrd6rgwfte70sjtwxfxmpjk6z2h8vgwdnc88clvac7kqqqqyqqqqqqqqqqqqlgqqqqqqgqjqwhtk6ldnue43vtseuajgyypkv20py670vmcea9qrrdcqjrpp0qvr0sqgcldapjmgfeuvj54q6jt2h36a0m9xme3rywacscd3a5ey3fgpgdr8eq");
-        let metadata = vec![1, 3, 2, 4, 3];
+        let metadata = String::from("Test metadata 1");
 
         payment_store
             .new_incoming_payment(
@@ -400,7 +400,7 @@ mod tests {
         let _network_fees_msat = 2_000;
         let description = String::from("Test description 2");
         let invoice = String::from("lnbcrt50u1p37590hdqqpp5wkf8saa4g3ejjhyh89uf5svhlus0ajrz0f9dm6tqnwxtupq3lyeqsp528valrymd092ev6s0srcwcnc3eufhnv453fzj7m5nscj2ejzvx7q9qrsgqnp4qfalfq06c807p3mlt4ggtufckg3nq79wnh96zjz748zmhl5vys3dgcqzysrzjqfky0rtekx6249z2dgvs4wc474q7yg3sx2u7hlvpua5ep5zla3akzqqqqyqqqqqqqqqqqqlgqqqqqqgqjq7n9ukth32d98unkxe692hgd7ke2vskmfz8d2s0part2ycd4vqneq3qgrj2jkvkq2vraa29xsll9lajgdq33yn76ny4h3wacsfxrdudcp575kp6");
-        let metadata = vec![1, 2, 3, 4, 5];
+        let metadata = String::from("Test metadata 2");
 
         payment_store
             .new_outgoing_payment(&hash, amount_msat, &description, &invoice, &metadata)
@@ -442,7 +442,7 @@ mod tests {
         let network_fees_msat = 500;
         let description = String::from("Test description 3");
         let invoice = String::from("lnbcrt100u1p375x7sdqqpp57argaznwm93lk9tvtpgj5mjr2pqh6gr4yp3rcsuzcv3xvz7hvg2ssp5edk06za3w47ww4x20zvja82ysql87ekn8zzvgg67ylkpt8pnjfws9qrsgqnp4qfalfq06c807p3mlt4ggtufckg3nq79wnh96zjz748zmhl5vys3dgcqzysrzjqfky0rtekx6249z2dgvs4wc474q7yg3sx2u7hlvpua5ep5zla3akzqqqqyqqqqqqqqqqqqlgqqqqqqgqjqgdqgl6n4qmkchkuvdzjjlun8lc524g57qwn2ctwxywdckxucwccjf692rynl4rnjq2qnepntg28umsvcdrthmn9fnlezu0kskmpujzcpvsvuml");
-        let metadata = vec![5, 4, 3, 2, 1];
+        let metadata = String::from("Test metadata 3");
 
         payment_store
             .new_outgoing_payment(&hash, amount_msat, &description, &invoice, &metadata)

--- a/eel/src/payment_store.rs
+++ b/eel/src/payment_store.rs
@@ -28,7 +28,7 @@ pub struct Payment {
     pub hash: String,
     pub amount_msat: u64,
     pub invoice: String,
-    pub timestamp: SystemTime,
+    pub latest_state_change_at: SystemTime,
     pub description: String,
     pub preimage: Option<String>,
     pub network_fees_msat: Option<u64>,
@@ -245,8 +245,8 @@ fn payment_from_row(row: &Row) -> rusqlite::Result<Payment> {
     let payment_state: u8 = row.get(9)?;
     let payment_state =
         PaymentState::try_from(payment_state).map_err(|_| rusqlite::Error::InvalidQuery)?;
-    let timestamp: chrono::DateTime<chrono::Utc> = row.get(10)?;
-    let timestamp = SystemTime::from(timestamp);
+    let latest_state_change_at: chrono::DateTime<chrono::Utc> = row.get(10)?;
+    let latest_state_change_at = SystemTime::from(latest_state_change_at);
     let description = row.get(11)?;
     Ok(Payment {
         payment_type,
@@ -254,7 +254,7 @@ fn payment_from_row(row: &Row) -> rusqlite::Result<Payment> {
         hash,
         amount_msat,
         invoice,
-        timestamp,
+        latest_state_change_at,
         description,
         preimage,
         network_fees_msat,

--- a/eel/src/payment_store.rs
+++ b/eel/src/payment_store.rs
@@ -33,7 +33,7 @@ pub struct Payment {
     pub preimage: Option<String>,
     pub network_fees_msat: Option<u64>,
     pub lsp_fees_msat: Option<u64>,
-    pub metadata: Option<Vec<u8>>,
+    pub metadata: Vec<u8>,
 }
 
 pub(crate) struct PaymentStore {
@@ -56,6 +56,7 @@ impl PaymentStore {
         lsp_fees_msat: u64,
         description: &str,
         invoice: &str,
+        metadata: &[u8],
     ) -> Result<()> {
         let tx = self
             .db_conn
@@ -63,8 +64,8 @@ impl PaymentStore {
             .map_to_permanent_failure("Failed to begin SQL transaction")?;
         tx.execute(
             "\
-            INSERT INTO payments (type, hash, amount_msat, lsp_fees_msat, description, invoice) \
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6)\
+            INSERT INTO payments (type, hash, amount_msat, lsp_fees_msat, description, invoice, metadata) \
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)\
             ",
             (
                 PaymentType::Receiving as u8,
@@ -73,6 +74,7 @@ impl PaymentStore {
                 lsp_fees_msat,
                 description,
                 invoice,
+                metadata
             ),
         )
         .map_to_invalid_input("Failed to add new incoming payment to payments db")?;
@@ -94,6 +96,7 @@ impl PaymentStore {
         amount_msat: u64,
         description: &str,
         invoice: &str,
+        metadata: &[u8],
     ) -> Result<()> {
         let tx = self
             .db_conn
@@ -101,8 +104,8 @@ impl PaymentStore {
             .map_to_permanent_failure("Failed to begin SQL transaction")?;
         tx.execute(
             "\
-            INSERT INTO payments (type, hash, amount_msat, description, invoice) \
-            VALUES (?1, ?2, ?3, ?4, ?5)\
+            INSERT INTO payments (type, hash, amount_msat, description, invoice, metadata) \
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)\
             ",
             (
                 PaymentType::Sending as u8,
@@ -110,6 +113,7 @@ impl PaymentStore {
                 amount_msat,
                 description,
                 invoice,
+                metadata,
             ),
         )
         .map_to_invalid_input("Failed to add new outgoing payment to payments db")?;
@@ -327,9 +331,17 @@ mod tests {
         let lsp_fees_msat = 2_000_000;
         let description = String::from("Test description 1");
         let invoice = String::from("lnbcrt1m1p37fe7udqqpp5e2mktq6ykgp0e9uljdrakvcy06wcwtswgwe7yl6jmfry4dke2t2ssp5s3uja8xn7tpeuctc62xqua6slpj40jrwlkuwmluv48g86r888g7s9qrsgqnp4qfalfq06c807p3mlt4ggtufckg3nq79wnh96zjz748zmhl5vys3dgcqzysrzjqwp6qac7ttkrd6rgwfte70sjtwxfxmpjk6z2h8vgwdnc88clvac7kqqqqyqqqqqqqqqqqqlgqqqqqqgqjqwhtk6ldnue43vtseuajgyypkv20py670vmcea9qrrdcqjrpp0qvr0sqgcldapjmgfeuvj54q6jt2h36a0m9xme3rywacscd3a5ey3fgpgdr8eq");
+        let metadata = vec![1, 3, 2, 4, 3];
 
         payment_store
-            .new_incoming_payment(&hash, amount_msat, lsp_fees_msat, &description, &invoice)
+            .new_incoming_payment(
+                &hash,
+                amount_msat,
+                lsp_fees_msat,
+                &description,
+                &invoice,
+                &metadata,
+            )
             .unwrap();
 
         let payments = payment_store.get_latest_payments(100).unwrap();
@@ -344,7 +356,7 @@ mod tests {
         assert_eq!(payment.preimage, None);
         assert_eq!(payment.network_fees_msat, None);
         assert_eq!(payment.lsp_fees_msat, Some(lsp_fees_msat));
-        assert_eq!(payment.metadata, None);
+        assert_eq!(payment.metadata, metadata);
 
         payment_store.fill_preimage(&hash, &preimage).unwrap();
 
@@ -367,9 +379,10 @@ mod tests {
         let _network_fees_msat = 2_000;
         let description = String::from("Test description 2");
         let invoice = String::from("lnbcrt50u1p37590hdqqpp5wkf8saa4g3ejjhyh89uf5svhlus0ajrz0f9dm6tqnwxtupq3lyeqsp528valrymd092ev6s0srcwcnc3eufhnv453fzj7m5nscj2ejzvx7q9qrsgqnp4qfalfq06c807p3mlt4ggtufckg3nq79wnh96zjz748zmhl5vys3dgcqzysrzjqfky0rtekx6249z2dgvs4wc474q7yg3sx2u7hlvpua5ep5zla3akzqqqqyqqqqqqqqqqqqlgqqqqqqgqjq7n9ukth32d98unkxe692hgd7ke2vskmfz8d2s0part2ycd4vqneq3qgrj2jkvkq2vraa29xsll9lajgdq33yn76ny4h3wacsfxrdudcp575kp6");
+        let metadata = vec![1, 2, 3, 4, 5];
 
         payment_store
-            .new_outgoing_payment(&hash, amount_msat, &description, &invoice)
+            .new_outgoing_payment(&hash, amount_msat, &description, &invoice, &metadata)
             .unwrap();
 
         let payments = payment_store.get_latest_payments(100).unwrap();
@@ -384,7 +397,7 @@ mod tests {
         assert_eq!(payment.preimage, None);
         assert_eq!(payment.network_fees_msat, None);
         assert_eq!(payment.lsp_fees_msat, None);
-        assert_eq!(payment.metadata, None);
+        assert_eq!(payment.metadata, metadata);
 
         payment_store.payment_failed(&hash).unwrap();
         let payments = payment_store.get_latest_payments(100).unwrap();
@@ -399,9 +412,10 @@ mod tests {
         let network_fees_msat = 500;
         let description = String::from("Test description 3");
         let invoice = String::from("lnbcrt100u1p375x7sdqqpp57argaznwm93lk9tvtpgj5mjr2pqh6gr4yp3rcsuzcv3xvz7hvg2ssp5edk06za3w47ww4x20zvja82ysql87ekn8zzvgg67ylkpt8pnjfws9qrsgqnp4qfalfq06c807p3mlt4ggtufckg3nq79wnh96zjz748zmhl5vys3dgcqzysrzjqfky0rtekx6249z2dgvs4wc474q7yg3sx2u7hlvpua5ep5zla3akzqqqqyqqqqqqqqqqqqlgqqqqqqgqjqgdqgl6n4qmkchkuvdzjjlun8lc524g57qwn2ctwxywdckxucwccjf692rynl4rnjq2qnepntg28umsvcdrthmn9fnlezu0kskmpujzcpvsvuml");
+        let metadata = vec![5, 4, 3, 2, 1];
 
         payment_store
-            .new_outgoing_payment(&hash, amount_msat, &description, &invoice)
+            .new_outgoing_payment(&hash, amount_msat, &description, &invoice, &metadata)
             .unwrap();
 
         let payments = payment_store.get_latest_payments(100).unwrap();
@@ -416,7 +430,7 @@ mod tests {
         assert_eq!(payment.preimage, None);
         assert_eq!(payment.network_fees_msat, None);
         assert_eq!(payment.lsp_fees_msat, None);
-        assert_eq!(payment.metadata, None);
+        assert_eq!(payment.metadata, metadata);
 
         payment_store
             .outgoing_payment_succeeded(&hash, &preimage, network_fees_msat)

--- a/eel/tests/persistence_test.rs
+++ b/eel/tests/persistence_test.rs
@@ -138,7 +138,7 @@ mod persistence_test {
         let initial_balance = node.get_node_info().channels_info.local_balance_msat;
 
         let invoice = node
-            .create_invoice(payment_amount, "test".to_string(), &[])
+            .create_invoice(payment_amount, "test".to_string(), vec![])
             .unwrap();
 
         nigiri::pay_invoice(paying_node, &invoice).unwrap();

--- a/eel/tests/persistence_test.rs
+++ b/eel/tests/persistence_test.rs
@@ -138,7 +138,7 @@ mod persistence_test {
         let initial_balance = node.get_node_info().channels_info.local_balance_msat;
 
         let invoice = node
-            .create_invoice(payment_amount, "test".to_string())
+            .create_invoice(payment_amount, "test".to_string(), &[])
             .unwrap();
 
         nigiri::pay_invoice(paying_node, &invoice).unwrap();

--- a/eel/tests/persistence_test.rs
+++ b/eel/tests/persistence_test.rs
@@ -138,7 +138,7 @@ mod persistence_test {
         let initial_balance = node.get_node_info().channels_info.local_balance_msat;
 
         let invoice = node
-            .create_invoice(payment_amount, "test".to_string(), vec![])
+            .create_invoice(payment_amount, "test".to_string(), String::new())
             .unwrap();
 
         nigiri::pay_invoice(paying_node, &invoice).unwrap();

--- a/eel/tests/rapid_gossip_sync_test.rs
+++ b/eel/tests/rapid_gossip_sync_test.rs
@@ -68,7 +68,7 @@ mod rapid_gossip_sync_test {
 
             // Pay from NigiriCln to 3L to create outbound liquidity
             let invoice_cln = node
-                .create_invoice(HUNDRED_K_SATS, "test".to_string(), vec![])
+                .create_invoice(HUNDRED_K_SATS, "test".to_string(), String::new())
                 .unwrap();
             assert!(invoice_cln.starts_with("lnbc"));
 
@@ -110,7 +110,7 @@ mod rapid_gossip_sync_test {
 
             // Pay from NigiriLnd to 3L to create outbound liquidity (LspdLnd -> NigiriLnd)
             let invoice_lnd = node
-                .create_invoice(HUNDRED_K_SATS, "test".to_string(), vec![])
+                .create_invoice(HUNDRED_K_SATS, "test".to_string(), String::new())
                 .unwrap();
             assert!(invoice_lnd.starts_with("lnbc"));
 
@@ -141,7 +141,7 @@ mod rapid_gossip_sync_test {
     fn send_payment_flow(node: &LightningNode, target: NodeInstance, amount_msat: u64) {
         let invoice = nigiri::issue_invoice(target, "test", amount_msat, 3600).unwrap();
         let initial_balance = nigiri::query_node_balance(target).unwrap();
-        node.pay_invoice(invoice, vec![]).unwrap();
+        node.pay_invoice(invoice, String::new()).unwrap();
         sleep(Duration::from_secs(2));
         let final_balance = nigiri::query_node_balance(target).unwrap();
         assert_eq!(final_balance - initial_balance, amount_msat);

--- a/eel/tests/rapid_gossip_sync_test.rs
+++ b/eel/tests/rapid_gossip_sync_test.rs
@@ -68,7 +68,7 @@ mod rapid_gossip_sync_test {
 
             // Pay from NigiriCln to 3L to create outbound liquidity
             let invoice_cln = node
-                .create_invoice(HUNDRED_K_SATS, "test".to_string())
+                .create_invoice(HUNDRED_K_SATS, "test".to_string(), &[])
                 .unwrap();
             assert!(invoice_cln.starts_with("lnbc"));
 
@@ -110,7 +110,7 @@ mod rapid_gossip_sync_test {
 
             // Pay from NigiriLnd to 3L to create outbound liquidity (LspdLnd -> NigiriLnd)
             let invoice_lnd = node
-                .create_invoice(HUNDRED_K_SATS, "test".to_string())
+                .create_invoice(HUNDRED_K_SATS, "test".to_string(), &[])
                 .unwrap();
             assert!(invoice_lnd.starts_with("lnbc"));
 
@@ -141,7 +141,7 @@ mod rapid_gossip_sync_test {
     fn send_payment_flow(node: &LightningNode, target: NodeInstance, amount_msat: u64) {
         let invoice = nigiri::issue_invoice(target, "test", amount_msat, 3600).unwrap();
         let initial_balance = nigiri::query_node_balance(target).unwrap();
-        node.pay_invoice(invoice).unwrap();
+        node.pay_invoice(invoice, &[]).unwrap();
         sleep(Duration::from_secs(2));
         let final_balance = nigiri::query_node_balance(target).unwrap();
         assert_eq!(final_balance - initial_balance, amount_msat);

--- a/eel/tests/rapid_gossip_sync_test.rs
+++ b/eel/tests/rapid_gossip_sync_test.rs
@@ -68,7 +68,7 @@ mod rapid_gossip_sync_test {
 
             // Pay from NigiriCln to 3L to create outbound liquidity
             let invoice_cln = node
-                .create_invoice(HUNDRED_K_SATS, "test".to_string(), &[])
+                .create_invoice(HUNDRED_K_SATS, "test".to_string(), vec![])
                 .unwrap();
             assert!(invoice_cln.starts_with("lnbc"));
 
@@ -110,7 +110,7 @@ mod rapid_gossip_sync_test {
 
             // Pay from NigiriLnd to 3L to create outbound liquidity (LspdLnd -> NigiriLnd)
             let invoice_lnd = node
-                .create_invoice(HUNDRED_K_SATS, "test".to_string(), &[])
+                .create_invoice(HUNDRED_K_SATS, "test".to_string(), vec![])
                 .unwrap();
             assert!(invoice_lnd.starts_with("lnbc"));
 
@@ -141,7 +141,7 @@ mod rapid_gossip_sync_test {
     fn send_payment_flow(node: &LightningNode, target: NodeInstance, amount_msat: u64) {
         let invoice = nigiri::issue_invoice(target, "test", amount_msat, 3600).unwrap();
         let initial_balance = nigiri::query_node_balance(target).unwrap();
-        node.pay_invoice(invoice, &[]).unwrap();
+        node.pay_invoice(invoice, vec![]).unwrap();
         sleep(Duration::from_secs(2));
         let final_balance = nigiri::query_node_balance(target).unwrap();
         assert_eq!(final_balance - initial_balance, amount_msat);

--- a/eel/tests/receiving_payments_test.rs
+++ b/eel/tests/receiving_payments_test.rs
@@ -195,7 +195,7 @@ mod receiving_payments_test {
 
     fn issue_invoice(node: &LightningNode, payment_amount: u64) -> String {
         let invoice = node
-            .create_invoice(payment_amount, "test".to_string(), vec![])
+            .create_invoice(payment_amount, "test".to_string(), String::new())
             .unwrap();
         assert!(invoice.starts_with("lnbc"));
 

--- a/eel/tests/receiving_payments_test.rs
+++ b/eel/tests/receiving_payments_test.rs
@@ -195,7 +195,7 @@ mod receiving_payments_test {
 
     fn issue_invoice(node: &LightningNode, payment_amount: u64) -> String {
         let invoice = node
-            .create_invoice(payment_amount, "test".to_string(), &[])
+            .create_invoice(payment_amount, "test".to_string(), vec![])
             .unwrap();
         assert!(invoice.starts_with("lnbc"));
 

--- a/eel/tests/receiving_payments_test.rs
+++ b/eel/tests/receiving_payments_test.rs
@@ -195,7 +195,7 @@ mod receiving_payments_test {
 
     fn issue_invoice(node: &LightningNode, payment_amount: u64) -> String {
         let invoice = node
-            .create_invoice(payment_amount, "test".to_string())
+            .create_invoice(payment_amount, "test".to_string(), &[])
             .unwrap();
         assert!(invoice.starts_with("lnbc"));
 

--- a/eel/tests/sending_payments_test.rs
+++ b/eel/tests/sending_payments_test.rs
@@ -27,7 +27,7 @@ mod sending_payments_test {
         assert!(node.get_node_info().channels_info.inbound_capacity_msat > REBALANCE_AMOUNT);
 
         let invoice = node
-            .create_invoice(REBALANCE_AMOUNT, "test".to_string())
+            .create_invoice(REBALANCE_AMOUNT, "test".to_string(), &[])
             .unwrap();
         assert!(invoice.starts_with("lnbc"));
 
@@ -47,7 +47,7 @@ mod sending_payments_test {
 
         let initial_balance = nigiri::query_node_balance(LspdLnd).unwrap();
 
-        node.pay_invoice(invoice).unwrap();
+        node.pay_invoice(invoice, &[]).unwrap();
         sleep(Duration::from_secs(2));
 
         let final_balance = nigiri::query_node_balance(LspdLnd).unwrap();

--- a/eel/tests/sending_payments_test.rs
+++ b/eel/tests/sending_payments_test.rs
@@ -27,7 +27,7 @@ mod sending_payments_test {
         assert!(node.get_node_info().channels_info.inbound_capacity_msat > REBALANCE_AMOUNT);
 
         let invoice = node
-            .create_invoice(REBALANCE_AMOUNT, "test".to_string(), vec![])
+            .create_invoice(REBALANCE_AMOUNT, "test".to_string(), String::new())
             .unwrap();
         assert!(invoice.starts_with("lnbc"));
 
@@ -47,7 +47,7 @@ mod sending_payments_test {
 
         let initial_balance = nigiri::query_node_balance(LspdLnd).unwrap();
 
-        node.pay_invoice(invoice, vec![]).unwrap();
+        node.pay_invoice(invoice, String::new()).unwrap();
         sleep(Duration::from_secs(2));
 
         let final_balance = nigiri::query_node_balance(LspdLnd).unwrap();

--- a/eel/tests/sending_payments_test.rs
+++ b/eel/tests/sending_payments_test.rs
@@ -27,7 +27,7 @@ mod sending_payments_test {
         assert!(node.get_node_info().channels_info.inbound_capacity_msat > REBALANCE_AMOUNT);
 
         let invoice = node
-            .create_invoice(REBALANCE_AMOUNT, "test".to_string(), &[])
+            .create_invoice(REBALANCE_AMOUNT, "test".to_string(), vec![])
             .unwrap();
         assert!(invoice.starts_with("lnbc"));
 
@@ -47,7 +47,7 @@ mod sending_payments_test {
 
         let initial_balance = nigiri::query_node_balance(LspdLnd).unwrap();
 
-        node.pay_invoice(invoice, &[]).unwrap();
+        node.pay_invoice(invoice, vec![]).unwrap();
         sleep(Duration::from_secs(2));
 
         let final_balance = nigiri::query_node_balance(LspdLnd).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ impl LightningNode {
         metadata: Vec<u8>,
     ) -> Result<String> {
         self.core_node
-            .create_invoice(amount_msat, description, &metadata)
+            .create_invoice(amount_msat, description, metadata)
     }
 
     pub fn decode_invoice(&self, invoice: String) -> Result<InvoiceDetails> {
@@ -67,7 +67,7 @@ impl LightningNode {
     }
 
     pub fn pay_invoice(&self, invoice: String, metadata: Vec<u8>) -> Result<()> {
-        self.core_node.pay_invoice(invoice, &metadata)
+        self.core_node.pay_invoice(invoice, metadata)
     }
 
     pub fn get_latest_payments(&self, number_of_payments: u32) -> Result<Vec<Payment>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,16 +52,22 @@ impl LightningNode {
         self.core_node.query_lsp_fee()
     }
 
-    pub fn create_invoice(&self, amount_msat: u64, description: String) -> Result<String> {
-        self.core_node.create_invoice(amount_msat, description)
+    pub fn create_invoice(
+        &self,
+        amount_msat: u64,
+        description: String,
+        metadata: Vec<u8>,
+    ) -> Result<String> {
+        self.core_node
+            .create_invoice(amount_msat, description, &metadata)
     }
 
     pub fn decode_invoice(&self, invoice: String) -> Result<InvoiceDetails> {
         self.core_node.decode_invoice(invoice)
     }
 
-    pub fn pay_invoice(&self, invoice: String) -> Result<()> {
-        self.core_node.pay_invoice(invoice)
+    pub fn pay_invoice(&self, invoice: String, metadata: Vec<u8>) -> Result<()> {
+        self.core_node.pay_invoice(invoice, &metadata)
     }
 
     pub fn get_latest_payments(&self, number_of_payments: u32) -> Result<Vec<Payment>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use eel::errors::{Error as LnError, Result, RuntimeErrorCode};
 use eel::keys_manager::{generate_secret, mnemonic_to_secret};
 use eel::lsp::LspFee;
 use eel::node_info::{ChannelsInfo, NodeInfo};
+use eel::payment_store::{Payment, PaymentState, PaymentType};
 use eel::secret::Secret;
 use eel::InvoiceDetails;
 use eel::LogLevel;
@@ -61,6 +62,10 @@ impl LightningNode {
 
     pub fn pay_invoice(&self, invoice: String) -> Result<()> {
         self.core_node.pay_invoice(invoice)
+    }
+
+    pub fn get_latest_payments(&self, number_of_payments: u32) -> Result<Vec<Payment>> {
+        self.core_node.get_latest_payments(number_of_payments)
     }
 
     pub fn foreground(&self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ impl LightningNode {
         &self,
         amount_msat: u64,
         description: String,
-        metadata: Vec<u8>,
+        metadata: String,
     ) -> Result<String> {
         self.core_node
             .create_invoice(amount_msat, description, metadata)
@@ -66,7 +66,7 @@ impl LightningNode {
         self.core_node.decode_invoice(invoice)
     }
 
-    pub fn pay_invoice(&self, invoice: String, metadata: Vec<u8>) -> Result<()> {
+    pub fn pay_invoice(&self, invoice: String, metadata: String) -> Result<()> {
         self.core_node.pay_invoice(invoice, metadata)
     }
 

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -171,7 +171,7 @@ dictionary Payment {
     string? preimage; // Hex representation of the preimage. Is only guaranteed be present on successful payments
     u64? network_fees_msat; // Routing fees paid in an `Sending` payment. Will only be present if payment was successful.
     u64? lsp_fees_msat; // LSP fees paid in a `Receiving` payment. Will always be present for `Receiving` payments but the amount is only paid if successful.
-    sequence<u8>? metadata;
+    sequence<u8> metadata;
 };
 
 interface LightningNode {
@@ -189,8 +189,10 @@ interface LightningNode {
     // Create an invoice to receive a payment with:
     //    - amount_msat - the smallest amount of millisats required for the node to accept the incoming payment (sender will have to pay fees on top of that amount)
     //    - description - a description to be embedded into the created invoice
+    //    - metadata - a blob of metadata that gets tied up to this payment. It can be used by the user of this library
+    //  to store data that is relevant to this payment. It is provided together with the respective payment in `get_latest_payments()`
     [Throws=LnError]
-    string create_invoice(u64 amount_msat, string description);
+    string create_invoice(u64 amount_msat, string description, sequence<u8> metadata);
 
     // Validates and, if valid, decodes an invoice returning detailed information
     //    - invoice - a BOLT-11 invoice (normally starts with lnbc)
@@ -202,8 +204,10 @@ interface LightningNode {
     // After this method returns, the consumer of this library will learn about a successful/failed payment through the
     // callbacks `payment_sent()` and `payment_failed()` in `EventsCallback`.
     //    - invoice - a BOLT-11 invoice (normally starts with lnbc)
+    //    - metadata - a blob of metadata that gets tied up to this payment. It can be used by the user of this library
+    //  to store data that is relevant to this payment. It is provided together with the respective payment in `get_latest_payments()`
     [Throws=LnError]
-    void pay_invoice(string invoice);
+    void pay_invoice(string invoice, sequence<u8> metadata);
 
     // Get a list of the latest payments
     //    - number_of_payments - the maximum number of payments that will be returned

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -166,7 +166,7 @@ dictionary Payment {
     string hash; // Hex representation of payment hash
     u64 amount_msat;
     string invoice;
-    timestamp timestamp; // The moment of the last state change (moment of creation if state is `Created`, moment of success if `Successful`, etc)
+    timestamp latest_state_change_at;
     string description; // The description embedded in the invoice. Given the length limit of this data, sometimes a hex hash of the description is provided instead.
     string? preimage; // Hex representation of the preimage. Is only guaranteed be present on successful payments
     u64? network_fees_msat; // Routing fees paid in an `Sending` payment. Will only be present if payment was successful.

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -166,6 +166,7 @@ dictionary Payment {
     string hash; // Hex representation of payment hash
     u64 amount_msat;
     string invoice;
+    timestamp created_at;
     timestamp latest_state_change_at;
     string description; // The description embedded in the invoice. Given the length limit of this data, sometimes a hex hash of the description is provided instead.
     string? preimage; // Hex representation of the preimage. Is only guaranteed be present on successful payments

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -172,7 +172,7 @@ dictionary Payment {
     string? preimage; // Hex representation of the preimage. Is only guaranteed be present on successful payments
     u64? network_fees_msat; // Routing fees paid in an `Sending` payment. Will only be present if payment was successful.
     u64? lsp_fees_msat; // LSP fees paid in a `Receiving` payment. Will always be present for `Receiving` payments but the amount is only paid if successful.
-    sequence<u8> metadata;
+    string metadata;
 };
 
 interface LightningNode {
@@ -190,10 +190,10 @@ interface LightningNode {
     // Create an invoice to receive a payment with:
     //    - amount_msat - the smallest amount of millisats required for the node to accept the incoming payment (sender will have to pay fees on top of that amount)
     //    - description - a description to be embedded into the created invoice
-    //    - metadata - a blob of metadata that gets tied up to this payment. It can be used by the user of this library
+    //    - metadata - a metadata string that gets tied up to this payment. It can be used by the user of this library
     //  to store data that is relevant to this payment. It is provided together with the respective payment in `get_latest_payments()`
     [Throws=LnError]
-    string create_invoice(u64 amount_msat, string description, sequence<u8> metadata);
+    string create_invoice(u64 amount_msat, string description, string metadata);
 
     // Validates and, if valid, decodes an invoice returning detailed information
     //    - invoice - a BOLT-11 invoice (normally starts with lnbc)
@@ -205,10 +205,10 @@ interface LightningNode {
     // After this method returns, the consumer of this library will learn about a successful/failed payment through the
     // callbacks `payment_sent()` and `payment_failed()` in `EventsCallback`.
     //    - invoice - a BOLT-11 invoice (normally starts with lnbc)
-    //    - metadata - a blob of metadata that gets tied up to this payment. It can be used by the user of this library
+    //    - metadata - a metadata string that gets tied up to this payment. It can be used by the user of this library
     //  to store data that is relevant to this payment. It is provided together with the respective payment in `get_latest_payments()`
     [Throws=LnError]
-    void pay_invoice(string invoice, sequence<u8> metadata);
+    void pay_invoice(string invoice, string metadata);
 
     // Get a list of the latest payments
     //    - number_of_payments - the maximum number of payments that will be returned

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -148,6 +148,32 @@ dictionary InvoiceDetails {
     duration expiry_interval; // The interval after which the invoice expires (invoice_timestamp + expiry_interval = timestamp of expiration)
 };
 
+enum PaymentType {
+    "Receiving",
+    "Sending",
+};
+
+enum PaymentState {
+    "Created",
+    "Succeeded",
+    "Failed",
+};
+
+// Information about an incoming or outgoing payment
+dictionary Payment {
+    PaymentType payment_type;
+    PaymentState payment_state;
+    string hash; // Hex representation of payment hash
+    u64 amount_msat;
+    string invoice;
+    timestamp timestamp; // The moment of the last state change (moment of creation if state is `Created`, moment of success if `Successful`, etc)
+    string description; // The description embedded in the invoice. Given the length limit of this data, sometimes a hex hash of the description is provided instead.
+    string? preimage; // Hex representation of the preimage. Is only guaranteed be present on successful payments
+    u64? network_fees_msat; // Routing fees paid in an `Sending` payment. Will only be present if payment was successful.
+    u64? lsp_fees_msat; // LSP fees paid in a `Receiving` payment. Will always be present for `Receiving` payments but the amount is only paid if successful.
+    sequence<u8>? metadata;
+};
+
 interface LightningNode {
     // Initiate the Lightning node and let it run in a background thread
     [Throws=LnError]
@@ -178,6 +204,11 @@ interface LightningNode {
     //    - invoice - a BOLT-11 invoice (normally starts with lnbc)
     [Throws=LnError]
     void pay_invoice(string invoice);
+
+    // Get a list of the latest payments
+    //    - number_of_payments - the maximum number of payments that will be returned
+    [Throws=LnError]
+    sequence<Payment> get_latest_payments(u32 number_of_payments);
 
     // Call the method when the app goes foreground, such that the user can interact with it.
     // The library starts running the background tasks more frequently to improve user experience.


### PR DESCRIPTION
This also changes the hash and preimage in `Payment` to hex strings and removes the unused `metadata` column.