### PR TITLE
Store timezone information

### DIFF
--- a/eel/examples/node/cli.rs
+++ b/eel/examples/node/cli.rs
@@ -203,7 +203,7 @@ fn list_payments(node: &LightningNode) -> Result<(), String> {
         let created_at: DateTime<Utc> = payment.created_at.timestamp.into();
         let latest_state_change_at: DateTime<Utc> = payment.latest_state_change_at.timestamp.into();
         println!(
-            "{:?} payment with created at {} and with latest state change at {}",
+            "{:?} payment created at {} and with latest state change at {}",
             payment.payment_type,
             created_at.format("%d/%m/%Y %T"),
             latest_state_change_at.format("%d/%m/%Y %T")
@@ -216,6 +216,7 @@ fn list_payments(node: &LightningNode) -> Result<(), String> {
         println!("      Preimage:           {:?}", payment.preimage);
         println!("      Description:        {}", payment.description);
         println!("      Invoice:            {}", payment.invoice);
+        println!();
     }
 
     Ok(())

--- a/eel/examples/node/cli.rs
+++ b/eel/examples/node/cli.rs
@@ -200,8 +200,8 @@ fn list_payments(node: &LightningNode) -> Result<(), String> {
     println!("Total of {} payments\n", payments.len());
 
     for payment in payments {
-        let created_at: DateTime<Utc> = payment.created_at.into();
-        let latest_state_change_at: DateTime<Utc> = payment.latest_state_change_at.into();
+        let created_at: DateTime<Utc> = payment.created_at.timestamp.into();
+        let latest_state_change_at: DateTime<Utc> = payment.latest_state_change_at.timestamp.into();
         println!(
             "{:?} payment with created at {} and with latest state change at {}",
             payment.payment_type,

--- a/eel/examples/node/main.rs
+++ b/eel/examples/node/main.rs
@@ -43,6 +43,7 @@ fn main() {
         lsp_url: "http://127.0.0.1:6666".to_string(),
         lsp_token: "iQUvOsdk4ognKshZB/CKN2vScksLhW8i13vTO+8SPvcyWJ+fHi8OLgUEvW1N3k2l".to_string(),
         local_persistence_path: BASE_DIR.to_string(),
+        timezone_id: String::from("example_timezone_id"),
     };
 
     let node = LightningNode::new(&config, remote_storage, events).unwrap();

--- a/eel/examples/node/main.rs
+++ b/eel/examples/node/main.rs
@@ -8,7 +8,7 @@ use file_storage::FileStorage;
 use crate::print_events_handler::PrintEventsHandler;
 
 use bitcoin::Network;
-use eel::config::Config;
+use eel::config::{Config, TzConfig};
 use eel::interfaces::RemoteStorage;
 use eel::keys_manager::mnemonic_to_secret;
 use eel::LightningNode;
@@ -43,7 +43,10 @@ fn main() {
         lsp_url: "http://127.0.0.1:6666".to_string(),
         lsp_token: "iQUvOsdk4ognKshZB/CKN2vScksLhW8i13vTO+8SPvcyWJ+fHi8OLgUEvW1N3k2l".to_string(),
         local_persistence_path: BASE_DIR.to_string(),
-        timezone_id: String::from("example_timezone_id"),
+        timezone_config: TzConfig {
+            timezone_id: String::from("example_timezone_id"),
+            timezone_utc_offset_secs: 1234,
+        },
     };
 
     let node = LightningNode::new(&config, remote_storage, events).unwrap();

--- a/eel/src/config.rs
+++ b/eel/src/config.rs
@@ -1,5 +1,11 @@
 use bitcoin::Network;
 
+#[derive(Clone, Debug)]
+pub struct TzConfig {
+    pub timezone_id: String,
+    pub timezone_utc_offset_secs: i32,
+}
+
 pub struct Config {
     pub network: Network,
     pub seed: [u8; 64],
@@ -8,7 +14,7 @@ pub struct Config {
     pub lsp_url: String,
     pub lsp_token: String,
     pub local_persistence_path: String,
-    pub timezone_id: String,
+    pub timezone_config: TzConfig,
 }
 
 impl Config {

--- a/eel/src/config.rs
+++ b/eel/src/config.rs
@@ -8,6 +8,7 @@ pub struct Config {
     pub lsp_url: String,
     pub lsp_token: String,
     pub local_persistence_path: String,
+    pub timezone_id: String,
 }
 
 impl Config {

--- a/eel/src/event_handler.rs
+++ b/eel/src/event_handler.rs
@@ -4,6 +4,7 @@ use crate::payment_store::PaymentStore;
 use crate::task_manager::TaskManager;
 use crate::types::ChannelManager;
 
+use crate::config::TzConfig;
 use bitcoin::hashes::hex::ToHex;
 use lightning::util::events::{Event, EventHandler, PaymentPurpose};
 use log::{error, info, trace};
@@ -22,9 +23,9 @@ impl LipaEventHandler {
         task_manager: Arc<Mutex<TaskManager>>,
         user_event_handler: Box<dyn interfaces::EventHandler>,
         payment_store_path: &str,
-        timezone_id: &str,
+        timezone_config: TzConfig,
     ) -> Result<Self> {
-        let payment_store = Mutex::new(PaymentStore::new(payment_store_path, timezone_id)?);
+        let payment_store = Mutex::new(PaymentStore::new(payment_store_path, timezone_config)?);
         Ok(Self {
             channel_manager,
             task_manager,

--- a/eel/src/event_handler.rs
+++ b/eel/src/event_handler.rs
@@ -22,8 +22,9 @@ impl LipaEventHandler {
         task_manager: Arc<Mutex<TaskManager>>,
         user_event_handler: Box<dyn interfaces::EventHandler>,
         payment_store_path: &str,
+        timezone_id: &str,
     ) -> Result<Self> {
-        let payment_store = Mutex::new(PaymentStore::new(payment_store_path)?);
+        let payment_store = Mutex::new(PaymentStore::new(payment_store_path, timezone_id)?);
         Ok(Self {
             channel_manager,
             task_manager,

--- a/eel/src/lib.rs
+++ b/eel/src/lib.rs
@@ -272,7 +272,7 @@ impl LightningNode {
             .to_str()
             .ok_or_invalid_input("Invalid local persistence path")?;
 
-        let payment_store = Mutex::new(PaymentStore::new(payment_store_path)?);
+        let payment_store = Mutex::new(PaymentStore::new(payment_store_path, &config.timezone_id)?);
 
         // Step 15. Initialize an EventHandler
         let event_handler = Arc::new(LipaEventHandler::new(
@@ -280,6 +280,7 @@ impl LightningNode {
             Arc::clone(&task_manager),
             user_event_handler,
             payment_store_path,
+            &config.timezone_id,
         )?);
 
         // Step 16. Initialize the ProbabilisticScorer

--- a/eel/src/lib.rs
+++ b/eel/src/lib.rs
@@ -272,7 +272,10 @@ impl LightningNode {
             .to_str()
             .ok_or_invalid_input("Invalid local persistence path")?;
 
-        let payment_store = Mutex::new(PaymentStore::new(payment_store_path, &config.timezone_id)?);
+        let payment_store = Mutex::new(PaymentStore::new(
+            payment_store_path,
+            config.timezone_config.clone(),
+        )?);
 
         // Step 15. Initialize an EventHandler
         let event_handler = Arc::new(LipaEventHandler::new(
@@ -280,7 +283,7 @@ impl LightningNode {
             Arc::clone(&task_manager),
             user_event_handler,
             payment_store_path,
-            &config.timezone_id,
+            config.timezone_config.clone(),
         )?);
 
         // Step 16. Initialize the ProbabilisticScorer

--- a/eel/src/payment_store.rs
+++ b/eel/src/payment_store.rs
@@ -22,14 +22,20 @@ pub enum PaymentState {
 }
 
 #[derive(PartialEq, Eq, Debug)]
+pub struct TzTime {
+    pub timestamp: SystemTime,
+    pub timezone_id: String,
+}
+
+#[derive(PartialEq, Eq, Debug)]
 pub struct Payment {
     pub payment_type: PaymentType,
     pub payment_state: PaymentState,
     pub hash: String,
     pub amount_msat: u64,
     pub invoice: String,
-    pub created_at: SystemTime,
-    pub latest_state_change_at: SystemTime,
+    pub created_at: TzTime,
+    pub latest_state_change_at: TzTime,
     pub description: String,
     pub preimage: Option<String>,
     pub network_fees_msat: Option<u64>,
@@ -39,15 +45,19 @@ pub struct Payment {
 
 pub(crate) struct PaymentStore {
     db_conn: Connection,
+    timezone_id: String,
 }
 
 impl PaymentStore {
-    pub fn new(db_path: &str) -> Result<Self> {
+    pub fn new(db_path: &str, timezone_id: &str) -> Result<Self> {
         let db_conn = Connection::open(db_path).map_to_invalid_input("Invalid db path")?;
 
         apply_migrations(&db_conn)?;
 
-        Ok(PaymentStore { db_conn })
+        Ok(PaymentStore {
+            db_conn,
+            timezone_id: String::from(timezone_id),
+        })
     }
 
     pub fn new_incoming_payment(
@@ -81,10 +91,14 @@ impl PaymentStore {
         .map_to_invalid_input("Failed to add new incoming payment to payments db")?;
         tx.execute(
             "\
-            INSERT INTO events (payment_id, type) \
-            VALUES (?1, ?2) \
+            INSERT INTO events (payment_id, type, timezone_id) \
+            VALUES (?1, ?2, ?3) \
             ",
-            (tx.last_insert_rowid(), PaymentState::Created as u8),
+            (
+                tx.last_insert_rowid(),
+                PaymentState::Created as u8,
+                &self.timezone_id,
+            ),
         )
         .map_to_invalid_input("Failed to add new incoming payment to payments db")?;
         tx.commit()
@@ -120,10 +134,14 @@ impl PaymentStore {
         .map_to_invalid_input("Failed to add new outgoing payment to payments db")?;
         tx.execute(
             "\
-            INSERT INTO events (payment_id, type) \
-            VALUES (?1, ?2) \
+            INSERT INTO events (payment_id, type, timezone_id) \
+            VALUES (?1, ?2, ?3) \
             ",
-            (tx.last_insert_rowid(), PaymentState::Created as u8),
+            (
+                tx.last_insert_rowid(),
+                PaymentState::Created as u8,
+                &self.timezone_id,
+            ),
         )
         .map_to_invalid_input("Failed to add new outgoing payment to payments db")?;
         tx.commit()
@@ -149,11 +167,11 @@ impl PaymentStore {
         self.db_conn
             .execute(
                 "\
-                INSERT INTO events (payment_id, type) \
+                INSERT INTO events (payment_id, type, timezone_id) \
                 VALUES (
-                    (SELECT payment_id FROM payments WHERE hash=?1), ?2)
+                    (SELECT payment_id FROM payments WHERE hash=?1), ?2, ?3)
                 ",
-                (hash, PaymentState::Succeeded as u8),
+                (hash, PaymentState::Succeeded as u8, &self.timezone_id),
             )
             .map_to_invalid_input("Failed to add payment confirmed event to payments db")?;
 
@@ -164,11 +182,11 @@ impl PaymentStore {
         self.db_conn
             .execute(
                 "\
-                INSERT INTO events (payment_id, type) \
+                INSERT INTO events (payment_id, type, timezone_id) \
                 VALUES (
-                    (SELECT payment_id FROM payments WHERE hash=?1), ?2)
+                    (SELECT payment_id FROM payments WHERE hash=?1), ?2, ?3)
                 ",
-                (hash, PaymentState::Failed as u8),
+                (hash, PaymentState::Failed as u8, &self.timezone_id),
             )
             .map_to_invalid_input("Failed to add payment failed event to payments db")?;
 
@@ -209,7 +227,9 @@ impl PaymentStore {
         let mut statement = self
             .db_conn
             .prepare("\
-            SELECT payments.payment_id, payments.type, hash, preimage, amount_msat, network_fees_msat, lsp_fees_msat, invoice, metadata, recent_events.type as state, recent_events.inserted_at, description, creation_events.inserted_at \
+            SELECT payments.payment_id, payments.type, hash, preimage, amount_msat, network_fees_msat, \
+            lsp_fees_msat, invoice, metadata, recent_events.type as state, recent_events.inserted_at, \
+            recent_events.timezone_id, description, creation_events.inserted_at, creation_events.timezone_id \
             FROM payments \
             JOIN recent_events ON payments.payment_id=recent_events.payment_id \
             JOIN creation_events ON payments.payment_id=creation_events.payment_id \
@@ -233,7 +253,9 @@ impl PaymentStore {
         let mut statement = self
             .db_conn
             .prepare("\
-            SELECT payments.payment_id, payments.type, hash, preimage, amount_msat, network_fees_msat, lsp_fees_msat, invoice, metadata, recent_events.type as state, recent_events.inserted_at, description, creation_events.inserted_at \
+            SELECT payments.payment_id, payments.type, hash, preimage, amount_msat, network_fees_msat, \
+            lsp_fees_msat, invoice, metadata, recent_events.type as state, recent_events.inserted_at, \
+            recent_events.timezone_id, description, creation_events.inserted_at, creation_events.timezone_id \
             FROM payments \
             JOIN recent_events ON payments.payment_id=recent_events.payment_id \
             JOIN creation_events ON payments.payment_id=creation_events.payment_id \
@@ -291,11 +313,19 @@ fn payment_from_row(row: &Row) -> rusqlite::Result<Payment> {
     let payment_state: u8 = row.get(9)?;
     let payment_state =
         PaymentState::try_from(payment_state).map_err(|_| rusqlite::Error::InvalidQuery)?;
-    let latest_state_change_at: chrono::DateTime<chrono::Utc> = row.get(10)?;
-    let latest_state_change_at = SystemTime::from(latest_state_change_at);
-    let description = row.get(11)?;
-    let created_at: chrono::DateTime<chrono::Utc> = row.get(12)?;
-    let created_at = SystemTime::from(created_at);
+    let latest_state_change_at_timestamp: chrono::DateTime<chrono::Utc> = row.get(10)?;
+    let latest_state_change_at_timezone_id = row.get(11)?;
+    let latest_state_change_at = TzTime {
+        timestamp: SystemTime::from(latest_state_change_at_timestamp),
+        timezone_id: latest_state_change_at_timezone_id,
+    };
+    let description = row.get(12)?;
+    let created_at_timestamp: chrono::DateTime<chrono::Utc> = row.get(13)?;
+    let created_at_timezone_id = row.get(14)?;
+    let created_at = TzTime {
+        timestamp: SystemTime::from(created_at_timestamp),
+        timezone_id: created_at_timezone_id,
+    };
     Ok(Payment {
         payment_type,
         payment_state,
@@ -333,6 +363,7 @@ fn apply_migrations(db_conn: &Connection) -> Result<()> {
               payment_id INTEGER NOT NULL,
               type INTEGER CHECK( type in (0, 1, 2) ) NOT NULL,
               inserted_at INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              timezone_id TEXT NOT NULL,
               FOREIGN KEY (payment_id) REFERENCES payments(payment_id)
             );
             CREATE VIEW IF NOT EXISTS creation_events
@@ -368,6 +399,7 @@ mod tests {
     use std::time::Duration;
 
     const TEST_DB_PATH: &str = ".3l_local_test";
+    const TEST_TZ_ID: &str = "test_timezone_id";
 
     #[test]
     fn test_migrations() {
@@ -384,7 +416,8 @@ mod tests {
     fn test_payment_exists() {
         let db_name = String::from("payment_exists.db3");
         reset_db(&db_name);
-        let mut payment_store = PaymentStore::new(&format!("{TEST_DB_PATH}/{db_name}")).unwrap();
+        let mut payment_store =
+            PaymentStore::new(&format!("{TEST_DB_PATH}/{db_name}"), TEST_TZ_ID).unwrap();
 
         let hash = vec![1, 2, 3, 4];
         let _preimage = vec![5, 6, 7, 8];
@@ -414,7 +447,8 @@ mod tests {
     fn test_payment_storage_flow() {
         let db_name = String::from("new_payment.db3");
         reset_db(&db_name);
-        let mut payment_store = PaymentStore::new(&format!("{TEST_DB_PATH}/{db_name}")).unwrap();
+        let mut payment_store =
+            PaymentStore::new(&format!("{TEST_DB_PATH}/{db_name}"), TEST_TZ_ID).unwrap();
 
         let payments = payment_store.get_latest_payments(100).unwrap();
         assert!(payments.is_empty());
@@ -453,8 +487,9 @@ mod tests {
         assert_eq!(payment.lsp_fees_msat, Some(lsp_fees_msat));
         assert_eq!(payment.metadata, metadata);
 
+        assert_eq!(payment.created_at.timezone_id, TEST_TZ_ID);
         assert_eq!(payment.created_at, payment.latest_state_change_at);
-        let created_at = payment.created_at;
+        let created_at = payment.created_at.timestamp;
 
         payment_store.fill_preimage(&hash, &preimage).unwrap();
 
@@ -472,9 +507,14 @@ mod tests {
         assert_eq!(payments.len(), 1);
         let payment = payments.get(0).unwrap();
         assert_eq!(payment.payment_state, PaymentState::Succeeded);
-        assert_eq!(payment.created_at, created_at);
-        assert_ne!(payment.created_at, payment.latest_state_change_at);
-        assert!(payment.created_at < payment.latest_state_change_at);
+        assert_eq!(payment.created_at.timezone_id, TEST_TZ_ID);
+        assert_eq!(payment.latest_state_change_at.timezone_id, TEST_TZ_ID);
+        assert_eq!(payment.created_at.timestamp, created_at);
+        assert_ne!(
+            payment.created_at.timestamp,
+            payment.latest_state_change_at.timestamp
+        );
+        assert!(payment.created_at.timestamp < payment.latest_state_change_at.timestamp);
 
         // New outgoing payment that fails
         let hash = vec![5, 6, 7, 8];
@@ -503,8 +543,9 @@ mod tests {
         assert_eq!(payment.lsp_fees_msat, None);
         assert_eq!(payment.metadata, metadata);
 
+        assert_eq!(payment.created_at.timezone_id, TEST_TZ_ID);
         assert_eq!(payment.created_at, payment.latest_state_change_at);
-        let created_at = payment.created_at;
+        let created_at = payment.created_at.timestamp;
 
         // To be able to test the difference between created_at and latest_state_change_at
         sleep(Duration::from_secs(1));
@@ -514,9 +555,14 @@ mod tests {
         assert_eq!(payments.len(), 2);
         let payment = payments.get(0).unwrap();
         assert_eq!(payment.payment_state, PaymentState::Failed);
-        assert_eq!(payment.created_at, created_at);
-        assert_ne!(payment.created_at, payment.latest_state_change_at);
-        assert!(payment.created_at < payment.latest_state_change_at);
+        assert_eq!(payment.created_at.timezone_id, TEST_TZ_ID);
+        assert_eq!(payment.latest_state_change_at.timezone_id, TEST_TZ_ID);
+        assert_eq!(payment.created_at.timestamp, created_at);
+        assert_ne!(
+            payment.created_at.timestamp,
+            payment.latest_state_change_at.timestamp
+        );
+        assert!(payment.created_at.timestamp < payment.latest_state_change_at.timestamp);
 
         // New outgoing payment that succeedes
         let hash = vec![1, 3, 5, 7];
@@ -545,8 +591,9 @@ mod tests {
         assert_eq!(payment.lsp_fees_msat, None);
         assert_eq!(payment.metadata, metadata);
 
+        assert_eq!(payment.created_at.timezone_id, TEST_TZ_ID);
         assert_eq!(payment.created_at, payment.latest_state_change_at);
-        let created_at = payment.created_at;
+        let created_at = payment.created_at.timestamp;
 
         // To be able to test the difference between created_at and latest_state_change_at
         sleep(Duration::from_secs(1));
@@ -560,9 +607,14 @@ mod tests {
         assert_eq!(payment.payment_state, PaymentState::Succeeded);
         assert_eq!(payment.preimage, Some(preimage.to_hex()));
         assert_eq!(payment.network_fees_msat, Some(network_fees_msat));
-        assert_eq!(payment.created_at, created_at);
-        assert_ne!(payment.created_at, payment.latest_state_change_at);
-        assert!(payment.created_at < payment.latest_state_change_at);
+        assert_eq!(payment.created_at.timezone_id, TEST_TZ_ID);
+        assert_eq!(payment.latest_state_change_at.timezone_id, TEST_TZ_ID);
+        assert_eq!(payment.created_at.timestamp, created_at);
+        assert_ne!(
+            payment.created_at.timestamp,
+            payment.latest_state_change_at.timestamp
+        );
+        assert!(payment.created_at.timestamp < payment.latest_state_change_at.timestamp);
 
         let payment_by_hash = payment_store.get_payment(&hash).unwrap();
         assert_eq!(payment, &payment_by_hash);

--- a/eel/tests/config/mod.rs
+++ b/eel/tests/config/mod.rs
@@ -1,5 +1,5 @@
 use bitcoin::Network;
-use eel::config::Config;
+use eel::config::{Config, TzConfig};
 use eel::keys_manager::generate_secret;
 
 pub const LOCAL_PERSISTENCE_PATH: &str = ".3l_local_test";
@@ -13,6 +13,9 @@ pub fn get_testing_config() -> Config {
         lsp_url: "http://127.0.0.1:6666".to_string(),
         lsp_token: "iQUvOsdk4ognKshZB/CKN2vScksLhW8i13vTO+8SPvcyWJ+fHi8OLgUEvW1N3k2l".to_string(),
         local_persistence_path: LOCAL_PERSISTENCE_PATH.to_string(),
-        timezone_id: String::from("int_test_timezone_id"),
+        timezone_config: TzConfig {
+            timezone_id: String::from("int_test_timezone_id"),
+            timezone_utc_offset_secs: 1234,
+        },
     }
 }

--- a/eel/tests/config/mod.rs
+++ b/eel/tests/config/mod.rs
@@ -13,5 +13,6 @@ pub fn get_testing_config() -> Config {
         lsp_url: "http://127.0.0.1:6666".to_string(),
         lsp_token: "iQUvOsdk4ognKshZB/CKN2vScksLhW8i13vTO+8SPvcyWJ+fHi8OLgUEvW1N3k2l".to_string(),
         local_persistence_path: LOCAL_PERSISTENCE_PATH.to_string(),
+        timezone_id: String::from("int_test_timezone_id"),
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,4 +9,5 @@ pub struct Config {
     pub lsp_url: String,
     pub lsp_token: String,
     pub local_persistence_path: String,
+    pub timezone_id: String,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use eel::config::TzConfig;
 use eel::Network;
 
 #[derive(Debug, Clone)]
@@ -9,5 +10,5 @@ pub struct Config {
     pub lsp_url: String,
     pub lsp_token: String,
     pub local_persistence_path: String,
-    pub timezone_id: String,
+    pub timezone_config: TzConfig,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use eel::errors::{Error as LnError, Result, RuntimeErrorCode};
 use eel::keys_manager::{generate_secret, mnemonic_to_secret};
 use eel::lsp::LspFee;
 use eel::node_info::{ChannelsInfo, NodeInfo};
-use eel::payment_store::{Payment, PaymentState, PaymentType};
+use eel::payment_store::{Payment, PaymentState, PaymentType, TzTime};
 use eel::secret::Secret;
 use eel::InvoiceDetails;
 use eel::LogLevel;
@@ -37,6 +37,7 @@ impl LightningNode {
             lsp_url: config.lsp_url,
             lsp_token: config.lsp_token,
             local_persistence_path: config.local_persistence_path,
+            timezone_id: config.timezone_id,
         };
         let remote_storage = Box::new(RemoteStorageMock::new(Arc::new(Storage::new())));
         let user_event_handler = Box::new(EventsImpl { events_callback });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod sanitize_input;
 pub use crate::callbacks::{CallbackError, EventsCallback};
 pub use crate::config::Config;
 use crate::eel_interface_impl::{EventsImpl, RemoteStorageMock};
+use eel::config::TzConfig;
 use eel::errors::{Error as LnError, Result, RuntimeErrorCode};
 use eel::keys_manager::{generate_secret, mnemonic_to_secret};
 use eel::lsp::LspFee;
@@ -37,7 +38,7 @@ impl LightningNode {
             lsp_url: config.lsp_url,
             lsp_token: config.lsp_token,
             local_persistence_path: config.local_persistence_path,
-            timezone_id: config.timezone_id,
+            timezone_config: config.timezone_config,
         };
         let remote_storage = Box::new(RemoteStorageMock::new(Arc::new(Storage::new())));
         let user_event_handler = Box::new(EventsImpl { events_callback });

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -27,6 +27,17 @@ enum Network {
     "Regtest",
 };
 
+// An object that holds timezone configuration values necessary for 3L to do timestamp annotation. These values get tied
+// together with every timestamp persisted in the local payment database.
+//
+// Fields:
+// * timezone_id - string identifier whose format is completely arbitrary and can be chosen by the user
+// * timezone_utc_offset_secs - offset from the UTC timezone in seconds
+dictionary TzConfig {
+    string timezone_id;
+    i32 timezone_utc_offset_secs;
+};
+
 // An object that holds all configuration needed to start a LightningNode instance.
 //
 // Fields:
@@ -40,7 +51,7 @@ enum Network {
 //     - "https://rapidsync.lightningdevkit.org/snapshot/" for Mainnet (PROD)
 //     - *WIP* for Testnet
 // * local_persistence_path - a path on the local filesystem where this library will directly persist data
-// * timezone_id - a timezone identifier that will become associated with every timestamp recorded in 3L's payment database.
+// * timezone_config - a timezone configuration object
 dictionary Config {
     Network network;
     sequence<u8> seed;
@@ -49,7 +60,7 @@ dictionary Config {
     string lsp_url;
     string lsp_token;
     string local_persistence_path;
-    string timezone_id;
+    TzConfig timezone_config;
 };
 
 [Error]
@@ -162,10 +173,11 @@ enum PaymentState {
     "Failed",
 };
 
-// A UTC timestamp accompanied by the ID of the timezone on which it was recorded
+// A UTC timestamp accompanied by the ID of the timezone on which it was recorded and the respective UTC offset
 dictionary TzTime {
     timestamp timestamp;
     string timezone_id;
+    i32 timezone_utc_offset_secs;
 };
 
 // Information about an incoming or outgoing payment

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -40,6 +40,7 @@ enum Network {
 //     - "https://rapidsync.lightningdevkit.org/snapshot/" for Mainnet (PROD)
 //     - *WIP* for Testnet
 // * local_persistence_path - a path on the local filesystem where this library will directly persist data
+// * timezone_id - a timezone identifier that will become associated with every timestamp recorded in 3L's payment database.
 dictionary Config {
     Network network;
     sequence<u8> seed;
@@ -48,6 +49,7 @@ dictionary Config {
     string lsp_url;
     string lsp_token;
     string local_persistence_path;
+    string timezone_id;
 };
 
 [Error]
@@ -160,6 +162,12 @@ enum PaymentState {
     "Failed",
 };
 
+// A UTC timestamp accompanied by the ID of the timezone on which it was recorded
+dictionary TzTime {
+    timestamp timestamp;
+    string timezone_id;
+};
+
 // Information about an incoming or outgoing payment
 dictionary Payment {
     PaymentType payment_type;
@@ -167,8 +175,8 @@ dictionary Payment {
     string hash; // Hex representation of payment hash
     u64 amount_msat;
     string invoice;
-    timestamp created_at;
-    timestamp latest_state_change_at;
+    TzTime created_at;
+    TzTime latest_state_change_at;
     string description; // The description embedded in the invoice. Given the length limit of this data, sometimes a hex hash of the description is provided instead.
     string? preimage; // Hex representation of the preimage. Is only guaranteed be present on successful payments
     u64? network_fees_msat; // Routing fees paid in an `Sending` payment. Will only be present if payment was successful.

--- a/tests/setup_3l/mod.rs
+++ b/tests/setup_3l/mod.rs
@@ -5,6 +5,7 @@ use uniffi_lipalightninglib::Config;
 use uniffi_lipalightninglib::LightningNode;
 
 use core::time::Duration;
+use eel::config::TzConfig;
 use eel::errors::RuntimeErrorCode;
 use std::fs;
 use std::thread::sleep;
@@ -33,6 +34,10 @@ impl NodeHandle {
                 lsp_url: eel_config.lsp_url,
                 lsp_token: eel_config.lsp_token,
                 local_persistence_path: eel_config.local_persistence_path,
+                timezone_config: TzConfig {
+                    timezone_id: String::from("int_test_timezone_id"),
+                    timezone_utc_offset_secs: 1234,
+                },
             },
         }
     }


### PR DESCRIPTION
The idea here is that the consumer of 3L always gets UTC timestamps, but knows the id of the timezone on which each timestamp was recorded. This allows for the conversion of the UTC timestamp to said timezone.