### PR TITLE
Remove storage-mock from eel/tests/setup/mod.rs

### DIFF
--- a/eel/tests/chain_sync_test.rs
+++ b/eel/tests/chain_sync_test.rs
@@ -8,8 +8,9 @@ mod chain_sync_test {
     use std::thread::sleep;
     use std::time::Duration;
 
+    use crate::setup::mocked_storage_setup::mocked_storage_node;
     use crate::setup::nigiri::{wait_for_new_channel_to_confirm, NodeInstance};
-    use crate::setup::{mocked_storage_node, nigiri, NodeHandle};
+    use crate::setup::{nigiri, NodeHandle};
     use crate::try_cmd_repeatedly;
 
     const HALF_SEC: Duration = Duration::from_millis(500);

--- a/eel/tests/node_info_test.rs
+++ b/eel/tests/node_info_test.rs
@@ -5,7 +5,8 @@ mod node_info_test {
     use bitcoin::secp256k1::PublicKey;
     use serial_test::file_serial;
 
-    use crate::setup::{mocked_storage_node, nigiri};
+    use crate::setup::mocked_storage_setup::mocked_storage_node;
+    use crate::setup::nigiri;
 
     #[test]
     #[file_serial(key, "/tmp/3l-int-tests-lock")]

--- a/eel/tests/node_info_test.rs
+++ b/eel/tests/node_info_test.rs
@@ -5,14 +5,14 @@ mod node_info_test {
     use bitcoin::secp256k1::PublicKey;
     use serial_test::file_serial;
 
-    use crate::setup::{nigiri, NodeHandle};
+    use crate::setup::{mocked_storage_node, nigiri};
 
     #[test]
     #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn test_get_node_info() {
         nigiri::setup_environment_with_lsp();
 
-        let node = NodeHandle::default().start().unwrap();
+        let node = mocked_storage_node().start().unwrap();
         let node_info = node.get_node_info();
 
         assert!(

--- a/eel/tests/p2p_connection_test.rs
+++ b/eel/tests/p2p_connection_test.rs
@@ -13,13 +13,13 @@ mod p2p_connection_test {
     use std::time::Duration;
 
     use crate::setup::nigiri::NodeInstance;
-    use crate::setup::{nigiri, NodeHandle};
+    use crate::setup::{mocked_storage_node, nigiri};
 
     #[test]
     #[file_parallel(key, "/tmp/3l-int-tests-lock")]
     fn test_p2p_connection() {
         nigiri::ensure_environment_running();
-        let node = NodeHandle::default().start().unwrap();
+        let node = mocked_storage_node().start().unwrap();
 
         sleep(Duration::from_millis(100));
         assert_eq!(node.get_node_info().num_peers, 1);
@@ -31,7 +31,7 @@ mod p2p_connection_test {
     #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn test_p2p_connection_with_unreliable_lsp() {
         nigiri::ensure_environment_running();
-        let node = NodeHandle::default().start().unwrap();
+        let node = mocked_storage_node().start().unwrap();
 
         // Test disconnect when LSP is down.
         {

--- a/eel/tests/p2p_connection_test.rs
+++ b/eel/tests/p2p_connection_test.rs
@@ -12,8 +12,9 @@ mod p2p_connection_test {
     use std::thread::sleep;
     use std::time::Duration;
 
+    use crate::setup::mocked_storage_setup::mocked_storage_node;
+    use crate::setup::nigiri;
     use crate::setup::nigiri::NodeInstance;
-    use crate::setup::{mocked_storage_node, nigiri};
 
     #[test]
     #[file_parallel(key, "/tmp/3l-int-tests-lock")]

--- a/eel/tests/persistence_test.rs
+++ b/eel/tests/persistence_test.rs
@@ -13,8 +13,9 @@ mod persistence_test {
     use std::thread::sleep;
     use std::time::Duration;
 
+    use crate::setup::mocked_storage_setup::mocked_storage_node_configurable;
     use crate::setup::nigiri::NodeInstance;
-    use crate::setup::{mocked_storage_node_configurable, nigiri, NodeHandle};
+    use crate::setup::{nigiri, NodeHandle};
     use crate::try_cmd_repeatedly;
 
     const ONE_SAT: u64 = 1_000;

--- a/eel/tests/rapid_gossip_sync_test.rs
+++ b/eel/tests/rapid_gossip_sync_test.rs
@@ -3,7 +3,7 @@ mod setup;
 #[cfg(feature = "nigiri")]
 mod rapid_gossip_sync_test {
     use crate::setup::nigiri::{wait_for_new_channel_to_confirm, NodeInstance};
-    use crate::setup::{nigiri, NodeHandle};
+    use crate::setup::{mocked_storage_node, nigiri};
     use crate::try_cmd_repeatedly;
     use bitcoin::hashes::hex::ToHex;
     use eel::LightningNode;
@@ -25,7 +25,7 @@ mod rapid_gossip_sync_test {
     #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn test_update_from_0_and_partial_update() {
         nigiri::setup_environment_with_lsp_rgs();
-        let node_handle = NodeHandle::default();
+        let node_handle = mocked_storage_node();
 
         let lspd_node_id = nigiri::query_node_info(NodeInstance::LspdLnd)
             .unwrap()

--- a/eel/tests/rapid_gossip_sync_test.rs
+++ b/eel/tests/rapid_gossip_sync_test.rs
@@ -2,8 +2,9 @@ mod setup;
 
 #[cfg(feature = "nigiri")]
 mod rapid_gossip_sync_test {
+    use crate::setup::mocked_storage_setup::mocked_storage_node;
+    use crate::setup::nigiri;
     use crate::setup::nigiri::{wait_for_new_channel_to_confirm, NodeInstance};
-    use crate::setup::{mocked_storage_node, nigiri};
     use crate::try_cmd_repeatedly;
     use bitcoin::hashes::hex::ToHex;
     use eel::LightningNode;

--- a/eel/tests/receiving_payments_test.rs
+++ b/eel/tests/receiving_payments_test.rs
@@ -10,7 +10,7 @@ mod receiving_payments_test {
     use std::time::Duration;
 
     use crate::setup::nigiri::NodeInstance;
-    use crate::setup::{nigiri, NodeHandle};
+    use crate::setup::{mocked_storage_node, nigiri};
     use crate::try_cmd_repeatedly;
 
     const ONE_SAT: u64 = 1_000;
@@ -32,7 +32,7 @@ mod receiving_payments_test {
         // Test receiving an invoice on a node that does not have any channel yet
         // resp, the channel opening is part of the payment process.
         nigiri::setup_environment_with_lsp();
-        let node_handle = NodeHandle::default();
+        let node_handle = mocked_storage_node();
 
         {
             let node = node_handle.start().unwrap();
@@ -122,7 +122,7 @@ mod receiving_payments_test {
     fn receive_multiple_payments_for_same_invoice() {
         nigiri::ensure_environment_running();
 
-        let node = NodeHandle::default().start().unwrap();
+        let node = mocked_storage_node().start().unwrap();
         let lipa_node_id = node.get_node_info().node_pubkey.to_hex();
         assert_eq!(node.get_node_info().num_peers, 1);
 

--- a/eel/tests/receiving_payments_test.rs
+++ b/eel/tests/receiving_payments_test.rs
@@ -9,8 +9,9 @@ mod receiving_payments_test {
     use std::thread::sleep;
     use std::time::Duration;
 
+    use crate::setup::mocked_storage_setup::mocked_storage_node;
+    use crate::setup::nigiri;
     use crate::setup::nigiri::NodeInstance;
-    use crate::setup::{mocked_storage_node, nigiri};
     use crate::try_cmd_repeatedly;
 
     const ONE_SAT: u64 = 1_000;

--- a/eel/tests/setup/mocked_storage_setup.rs
+++ b/eel/tests/setup/mocked_storage_setup.rs
@@ -1,0 +1,15 @@
+use crate::setup::mocked_remote_storage::MockedRemoteStorage;
+use crate::setup::{mocked_remote_storage, NodeHandle};
+use std::sync::Arc;
+use storage_mock::Storage;
+
+pub fn mocked_storage_node() -> NodeHandle<MockedRemoteStorage> {
+    mocked_storage_node_configurable(mocked_remote_storage::Config::default())
+}
+
+pub fn mocked_storage_node_configurable(
+    config: mocked_remote_storage::Config,
+) -> NodeHandle<MockedRemoteStorage> {
+    let storage = MockedRemoteStorage::new(Arc::new(Storage::new()), config);
+    NodeHandle::new(storage)
+}


### PR DESCRIPTION
The previous idea of reusing all of eel's int test environment setup in 3L with [a hacky solution](https://github.com/getlipa/lipa-lightning-lib/blob/53e4622f5565880a1296cdf34d5bb95dd9aa5b5c/tests/node_info_test.rs#L4) comes back to bite us in the ass.

The problem is that in the future, we don't want to use `storage-mock` (crate within this repo) for 3L anymore, but instead we want to use an actual RemoteStorage client. Therefore we are going to remove the storage-mock crate from `3L`'s dependencies. But since we steal `eel`s `setup/mod.rs` file, where there is still a `use storage_mock::Storage;` statement, the compiler will say it cannot find this crate.

So this PR introduces even more hackiness, to deal with the previous hacky solution: It's sole purpose is to move `use storage_mock::Storage;` out of `eel/tests/setup/mod.rs` such that it can be imported into 3L without any issues.