### PR TITLE
User event callback does not return errors

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -1,40 +1,9 @@
-use std::fmt::Debug;
-use uniffi::UnexpectedUniFFICallbackError;
-
-#[derive(Debug, thiserror::Error)]
-pub enum CallbackError {
-    #[error("InvalidInput")]
-    InvalidInput,
-
-    #[error("RuntimeError")]
-    RuntimeError,
-
-    #[error("PermanentFailure")]
-    PermanentFailure,
-
-    #[error("UnexpectedUniFFICallbackError")]
-    UnexpectedUniFFI,
-}
-
-impl From<UnexpectedUniFFICallbackError> for CallbackError {
-    fn from(_error: UnexpectedUniFFICallbackError) -> Self {
-        CallbackError::UnexpectedUniFFI
-    }
-}
-
-pub type CallbackResult<T> = Result<T, CallbackError>;
-
 pub trait EventsCallback: Send + Sync {
-    fn payment_received(&self, payment_hash: String, amount_msat: u64) -> CallbackResult<()>;
+    fn payment_received(&self, payment_hash: String, amount_msat: u64);
 
-    fn channel_closed(&self, channel_id: String, reason: String) -> CallbackResult<()>;
+    fn channel_closed(&self, channel_id: String, reason: String);
 
-    fn payment_sent(
-        &self,
-        payment_hash: String,
-        payment_preimage: String,
-        fee_paid_msat: u64,
-    ) -> CallbackResult<()>;
+    fn payment_sent(&self, payment_hash: String, payment_preimage: String, fee_paid_msat: u64);
 
-    fn payment_failed(&self, payment_hash: String) -> CallbackResult<()>;
+    fn payment_failed(&self, payment_hash: String);
 }

--- a/src/eel_interface_impl.rs
+++ b/src/eel_interface_impl.rs
@@ -3,7 +3,6 @@ use eel::interfaces::{EventHandler, RemoteStorage};
 use eel::MapToError;
 
 use honey_badger::Auth;
-use log::error;
 use mole::ChannelStatePersistenceClient;
 use perro::runtime_error;
 use std::sync::Arc;
@@ -111,32 +110,20 @@ pub(crate) struct EventsImpl {
 
 impl EventHandler for EventsImpl {
     fn payment_received(&self, payment_hash: String, amount_msat: u64) {
-        if let Err(e) = self
-            .events_callback
-            .payment_received(payment_hash, amount_msat)
-        {
-            error!("Error on handling Payment Received event: {e}");
-        }
+        self.events_callback
+            .payment_received(payment_hash, amount_msat);
     }
 
     fn payment_sent(&self, payment_hash: String, payment_preimage: String, fee_paid_msat: u64) {
-        if let Err(e) =
-            self.events_callback
-                .payment_sent(payment_hash, payment_preimage, fee_paid_msat)
-        {
-            error!("Error on handling Payment Sent event: {e}");
-        }
+        self.events_callback
+            .payment_sent(payment_hash, payment_preimage, fee_paid_msat);
     }
 
     fn payment_failed(&self, payment_hash: String) {
-        if let Err(e) = self.events_callback.payment_failed(payment_hash) {
-            error!("Error on handling Payment Failed event: {e}");
-        }
+        self.events_callback.payment_failed(payment_hash);
     }
 
     fn channel_closed(&self, channel_id: String, reason: String) {
-        if let Err(e) = self.events_callback.channel_closed(channel_id, reason) {
-            error!("Error on handling Channel Closed event: {e}");
-        }
+        self.events_callback.channel_closed(channel_id, reason);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod exchange_rate_provider;
 mod native_logger;
 mod sanitize_input;
 
-pub use crate::callbacks::{CallbackError, EventsCallback};
+pub use crate::callbacks::EventsCallback;
 pub use crate::config::Config;
 use crate::eel_interface_impl::{EventsImpl, RemoteStorageGraphql};
 use crate::exchange_rate_provider::ExchangeRateProviderImpl;

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -70,24 +70,6 @@ dictionary Config {
     string backend_health_url;
 };
 
-[Error]
-enum CallbackError {
-    // Invalid input.
-    // Consider fixing the input and retrying the request.
-    "InvalidInput",
-
-    // Recoverable problem (e.g. network issue, problem with en external service).
-    // Consider retrying the request.
-    "RuntimeError",
-
-    // Unrecoverable problem (e.g. internal invariant broken).
-    // Consider suggesting the user to report the issue to the developers.
-    "PermanentFailure",
-
-    // This value is required by UniFFI library. Do not use the value directly.
-    "UnexpectedUniFFI",
-};
-
 // Asynchronous events that the consumer of this library needs/wants to handle are delivered through this interface.
 // These callbacks will only be called once, so the consumer of this library should be quick to persist information
 // regarding their occurrence. Otherwise, it's possible that an event gets "lost" if the app is terminated before
@@ -99,7 +81,6 @@ callback interface EventsCallback {
     // * payment_hash - can be used cross-reference this claimed payment with a previously issued invoice.
     // * amount_msat - will be at least as high as the value requested in the invoice but it's possible
     //      for it to be higher.
-    [Throws=CallbackError]
     void payment_received(string payment_hash, u64 amount_msat);
 
     // This callback will be called when a payment has been successfully sent (the payee received the funds)
@@ -108,14 +89,12 @@ callback interface EventsCallback {
     // * payment_hash - the hash of the payment can be used to cross-reference this event to the payment that has succeeded
     // * payment_preimage - the preimage of the payment can be used as proof of payment
     // * fee_paid_msat - the amount that was paid in routing fees
-    [Throws=CallbackError]
     void payment_sent(string payment_hash, string payment_preimage, u64 fee_paid_msat);
 
     // This callback will be called when a payment has failed and no further attempts will be pursued.
     //
     // Parameters:
     // * payment_hash - the hash of the payment can be used to cross-reference this event to the payment that has failed
-    [Throws=CallbackError]
     void payment_failed(string payment_hash);
 
     // This callback will be called when a channel has started closing
@@ -127,7 +106,6 @@ callback interface EventsCallback {
     // Parameters:
     // * channel_id - Channel ID encoded in hexadecimal.
     // * reason - provides a reason for the close
-    [Throws=CallbackError]
     void channel_closed(string channel_id, string reason);
 };
 

--- a/tests/print_events_handler/mod.rs
+++ b/tests/print_events_handler/mod.rs
@@ -1,45 +1,33 @@
 use log::info;
-use uniffi_lipalightninglib::CallbackError;
 use uniffi_lipalightninglib::EventsCallback;
-
-pub type CallbackResult<T> = std::result::Result<T, CallbackError>;
 
 pub struct PrintEventsHandler {}
 
 impl EventsCallback for PrintEventsHandler {
-    fn payment_received(&self, payment_hash: String, amount_msat: u64) -> CallbackResult<()> {
+    fn payment_received(&self, payment_hash: String, amount_msat: u64) {
         info!(
             "Received a payment! Value of {} milli satoshis and payment hash is {}",
             amount_msat, payment_hash
         );
-        Ok(())
     }
 
-    fn channel_closed(&self, channel_id: String, reason: String) -> CallbackResult<()> {
+    fn channel_closed(&self, channel_id: String, reason: String) {
         info!(
             "A channel was closed! Channel ID {} was closed due to {}",
             channel_id, reason
         );
-        Ok(())
     }
 
-    fn payment_sent(
-        &self,
-        payment_hash: String,
-        payment_preimage: String,
-        fee_paid_msat: u64,
-    ) -> CallbackResult<()> {
+    fn payment_sent(&self, payment_hash: String, payment_preimage: String, fee_paid_msat: u64) {
         info!(
             "A payment has been successfully sent! Its preimage is {}, the hash is {}, and a total of {} msats were paid in lightning fees",
             payment_preimage,
             payment_hash,
             fee_paid_msat
         );
-        Ok(())
     }
 
-    fn payment_failed(&self, payment_hash: String) -> CallbackResult<()> {
+    fn payment_failed(&self, payment_hash: String) {
         info!("A payment has failed! Its hash is {}", payment_hash);
-        Ok(())
     }
 }


### PR DESCRIPTION
3L cannot do much about callbacks errors apart from logging. Why bother ourselves if the client can do it also?