### PR TITLE
Store currency code in rates

### DIFF
--- a/eel/examples/eel-node/cli.rs
+++ b/eel/examples/eel-node/cli.rs
@@ -9,11 +9,7 @@ use std::path::Path;
 
 use crate::LightningNode;
 
-pub(crate) fn poll_for_user_input(
-    node: &LightningNode,
-    log_file_path: &str,
-    fiat_currency: String,
-) {
+pub(crate) fn poll_for_user_input(node: &LightningNode, log_file_path: &str) {
     println!("{}", "Eel Example Node".yellow().bold());
     println!("Detailed logs are available at {}", log_file_path);
     println!("To stop the node, please type \"stop\" for a graceful shutdown.");
@@ -49,7 +45,7 @@ pub(crate) fn poll_for_user_input(
                     lsp_fee(node);
                 }
                 "exchangerates" => {
-                    if let Err(message) = get_exchange_rates(node, &fiat_currency) {
+                    if let Err(message) = get_exchange_rates(node) {
                         println!("{}", message.red());
                     }
                 }
@@ -150,10 +146,10 @@ fn node_info(node: &LightningNode) {
     );
 }
 
-fn get_exchange_rates(node: &LightningNode, fiat_currency: &str) -> Result<(), String> {
+fn get_exchange_rates(node: &LightningNode) -> Result<(), String> {
     let rates = node.get_exchange_rates().map_err(|e| e.to_string())?;
-    println!("{fiat_currency}: {} sats", rates.default_currency);
-    println!("USD: {} sats", rates.usd);
+    println!("{}: {} sats", rates.currency_code, rates.rate);
+    println!("USD: {} sats", rates.usd_rate);
     Ok(())
 }
 

--- a/eel/examples/eel-node/main.rs
+++ b/eel/examples/eel-node/main.rs
@@ -39,7 +39,7 @@ fn main() {
     let config = Config {
         network: Network::Regtest,
         seed,
-        fiat_currency: fiat_currency.clone(),
+        fiat_currency,
         esplora_api_url: "http://localhost:30000".to_string(),
         rgs_url: "http://localhost:8080/snapshot/".to_string(),
         lsp_url: "http://127.0.0.1:6666".to_string(),
@@ -57,7 +57,7 @@ fn main() {
 
     // Lauch CLI
     sleep(Duration::from_secs(1));
-    cli::poll_for_user_input(&node, &format!("{BASE_DIR}/{LOG_FILE}"), fiat_currency);
+    cli::poll_for_user_input(&node, &format!("{BASE_DIR}/{LOG_FILE}"));
 }
 
 fn init_logger() {

--- a/eel/src/interfaces.rs
+++ b/eel/src/interfaces.rs
@@ -24,8 +24,9 @@ pub trait EventHandler: Send + Sync {
 
 #[derive(Clone)]
 pub struct ExchangeRates {
-    pub default_currency: u32,
-    pub usd: u32,
+    pub currency_code: String,
+    pub rate: u32,
+    pub usd_rate: u32,
 }
 
 pub trait ExchangeRateProvider: Send + Sync {

--- a/eel/src/payment_store.rs
+++ b/eel/src/payment_store.rs
@@ -38,12 +38,12 @@ pub struct FiatValues {
 }
 
 impl FiatValues {
-    pub fn from_amount_msat(amount_msat: u64, fiat: &str, exchange_rates: &ExchangeRates) -> Self {
+    pub fn from_amount_msat(amount_msat: u64, exchange_rates: &ExchangeRates) -> Self {
         // fiat amount in thousandths of the major fiat unit
-        let amount = amount_msat / (exchange_rates.default_currency as u64);
-        let amount_usd = amount_msat / (exchange_rates.usd as u64);
+        let amount = amount_msat / (exchange_rates.rate as u64);
+        let amount_usd = amount_msat / (exchange_rates.usd_rate as u64);
         FiatValues {
-            fiat: fiat.to_string(),
+            fiat: exchange_rates.currency_code.clone(),
             amount,
             amount_usd,
         }
@@ -776,27 +776,28 @@ mod tests {
     #[test]
     fn test_fiat_value_from_exchange_rate() {
         let exchange_rates = ExchangeRates {
-            default_currency: 5_000,
-            usd: 5_000,
+            currency_code: "EUR".to_string(),
+            rate: 5_000,
+            usd_rate: 5_000,
         };
         assert_eq!(
-            FiatValues::from_amount_msat(1_000, "EUR", &exchange_rates).amount,
+            FiatValues::from_amount_msat(1_000, &exchange_rates).amount,
             0
         );
         assert_eq!(
-            FiatValues::from_amount_msat(10_000, "EUR", &exchange_rates).amount,
+            FiatValues::from_amount_msat(10_000, &exchange_rates).amount,
             2
         );
         assert_eq!(
-            FiatValues::from_amount_msat(100_000, "EUR", &exchange_rates).amount,
+            FiatValues::from_amount_msat(100_000, &exchange_rates).amount,
             20
         );
         assert_eq!(
-            FiatValues::from_amount_msat(1_000_000, "EUR", &exchange_rates).amount,
+            FiatValues::from_amount_msat(1_000_000, &exchange_rates).amount,
             200
         );
         assert_eq!(
-            FiatValues::from_amount_msat(10_000_000, "EUR", &exchange_rates).amount,
+            FiatValues::from_amount_msat(10_000_000, &exchange_rates).amount,
             2_000
         );
     }

--- a/eel/src/task_manager.rs
+++ b/eel/src/task_manager.rs
@@ -251,12 +251,12 @@ impl TaskManager {
             let exchange_rates = Arc::clone(&exchange_rates);
             async move {
                 match tokio::task::spawn_blocking(move || {
-                    let default_currency =
-                        exchange_rate_provider.query_exchange_rate(fiat_currency)?;
-                    let usd = exchange_rate_provider.query_exchange_rate("USD".to_string())?;
+                    let rate = exchange_rate_provider.query_exchange_rate(fiat_currency.clone())?;
+                    let usd_rate = exchange_rate_provider.query_exchange_rate("USD".to_string())?;
                     let rates = ExchangeRates {
-                        default_currency,
-                        usd,
+                        currency_code: fiat_currency,
+                        rate,
+                        usd_rate,
                     };
                     Ok(rates) as Result<ExchangeRates>
                 })
@@ -276,9 +276,8 @@ impl TaskManager {
         })
     }
 
-    pub fn change_fiat_currency(&mut self, fiat_currency: &str) {
-        self.fiat_currency = String::from(fiat_currency);
-        *self.exchange_rates.lock().unwrap() = None;
+    pub fn change_fiat_currency(&mut self, fiat_currency: String) {
+        self.fiat_currency = fiat_currency;
     }
 }
 

--- a/examples/3l-node/cli.rs
+++ b/examples/3l-node/cli.rs
@@ -11,11 +11,7 @@ use std::path::Path;
 
 use crate::LightningNode;
 
-pub(crate) fn poll_for_user_input(
-    node: &LightningNode,
-    log_file_path: &str,
-    fiat_currency: String,
-) {
+pub(crate) fn poll_for_user_input(node: &LightningNode, log_file_path: &str) {
     println!("{}", "3L Example Node".blue().bold());
     println!("Detailed logs are available at {}", log_file_path);
     println!("To stop the node, please type \"stop\" for a graceful shutdown.");
@@ -27,7 +23,6 @@ pub(crate) fn poll_for_user_input(
     let prompt = "3L ϟ ".bold().blue().to_string();
     let history_path = Path::new(".3l_cli_history");
     let mut rl = setup_editor(&history_path);
-    let mut fiat_currency = fiat_currency;
     loop {
         let line = match rl.readline(&prompt) {
             Ok(line) => line,
@@ -54,7 +49,7 @@ pub(crate) fn poll_for_user_input(
                     }
                 }
                 "exchangerates" => {
-                    if let Err(message) = get_exchange_rates(node, &fiat_currency) {
+                    if let Err(message) = get_exchange_rates(node) {
                         println!("{}", message.red());
                     }
                 }
@@ -64,17 +59,15 @@ pub(crate) fn poll_for_user_input(
                     }
                 }
                 "changecurrency" => {
-                    fiat_currency = match words
+                    match words
                         .next()
                         .ok_or_else(|| "Error: fiat currency code is required".to_string())
                     {
                         Ok(c) => {
                             change_currency(node, c);
-                            c.to_string()
                         }
                         Err(e) => {
                             println!("{}", e.red());
-                            fiat_currency
                         }
                     };
                 }
@@ -236,10 +229,10 @@ fn node_info(node: &LightningNode) {
     );
 }
 
-fn get_exchange_rates(node: &LightningNode, fiat_currency: &str) -> Result<(), String> {
+fn get_exchange_rates(node: &LightningNode) -> Result<(), String> {
     let rates = node.get_exchange_rates().map_err(|e| e.to_string())?;
-    println!("{fiat_currency}: {} sats", rates.default_currency);
-    println!("USD: {} sats", rates.usd);
+    println!("{}: {} sats", rates.currency_code, rates.rate);
+    println!("USD: {} sats", rates.usd_rate);
     Ok(())
 }
 

--- a/examples/3l-node/main.rs
+++ b/examples/3l-node/main.rs
@@ -35,7 +35,7 @@ fn main() {
     let config = Config {
         network: Network::Regtest,
         seed,
-        fiat_currency: fiat_currency.clone(),
+        fiat_currency,
         esplora_api_url: "http://localhost:30000".to_string(),
         rgs_url: "http://localhost:8080/snapshot/".to_string(),
         lsp_url: "http://127.0.0.1:6666".to_string(),
@@ -53,7 +53,7 @@ fn main() {
 
     // Lauch CLI
     sleep(Duration::from_secs(1));
-    cli::poll_for_user_input(&node, &format!("{BASE_DIR}/{LOG_FILE}"), fiat_currency);
+    cli::poll_for_user_input(&node, &format!("{BASE_DIR}/{LOG_FILE}"));
 }
 
 fn init_logger() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ impl LightningNode {
     }
 
     pub fn change_fiat_currency(&self, fiat_currency: String) {
-        self.core_node.change_fiat_currency(&fiat_currency);
+        self.core_node.change_fiat_currency(fiat_currency);
     }
 }
 

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -274,8 +274,9 @@ interface LightningNode {
 
 // Exchange rates as sats per major unit.
 dictionary ExchangeRates {
-    u32 default_currency;
-    u32 usd;
+    string currency_code;
+    u32 rate;
+    u32 usd_rate;
 };
 
 dictionary ChannelsInfo {


### PR DESCRIPTION
It will eliminate the risk of interpreting old rates as rates for the newly configured currency.