### PR TITLE
Log more when starting node in integration tests

### DIFF
--- a/eel/tests/node_info_test.rs
+++ b/eel/tests/node_info_test.rs
@@ -14,7 +14,7 @@ mod node_info_test {
     fn test_get_node_info() {
         nigiri::setup_environment_with_lsp();
 
-        let node = mocked_storage_node().start().unwrap();
+        let node = mocked_storage_node().start_or_panic();
         let node_info = node.get_node_info();
 
         assert!(

--- a/eel/tests/p2p_connection_test.rs
+++ b/eel/tests/p2p_connection_test.rs
@@ -21,7 +21,7 @@ mod p2p_connection_test {
     #[file_parallel(key, "/tmp/3l-int-tests-lock")]
     fn test_p2p_connection() {
         nigiri::ensure_environment_running();
-        let node = mocked_storage_node().start().unwrap();
+        let node = mocked_storage_node().start_or_panic();
 
         wait_for_eq!(node.get_node_info().num_peers, 1);
         let peers = nigiri::list_peers(NodeInstance::LspdLnd).unwrap();
@@ -32,7 +32,7 @@ mod p2p_connection_test {
     #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn test_p2p_connection_with_unreliable_lsp() {
         nigiri::ensure_environment_running();
-        let node = mocked_storage_node().start().unwrap();
+        let node = mocked_storage_node().start_or_panic();
 
         // Test disconnect when LSP is down.
         {

--- a/eel/tests/persistence_test.rs
+++ b/eel/tests/persistence_test.rs
@@ -107,7 +107,7 @@ mod persistence_test {
 
     fn run_flow_1st_jit_channel<S: RemoteStorage + Clone + 'static>(node_handle: &NodeHandle<S>) {
         {
-            let node = node_handle.start().unwrap();
+            let node = node_handle.start_or_panic();
             wait_for_eq!(node.get_node_info().num_peers, 1);
 
             let lspd_node_id = nigiri::query_node_info(NodeInstance::LspdLnd)
@@ -133,7 +133,7 @@ mod persistence_test {
 
     fn run_flow_2nd_jit_channel<S: RemoteStorage + Clone + 'static>(node_handle: &NodeHandle<S>) {
         {
-            let node = node_handle.start().unwrap();
+            let node = node_handle.start_or_panic();
 
             // Wait for p2p connection to be reestablished and channels marked active
             wait_for_eq!(node.get_node_info().channels_info.num_usable_channels, 1);

--- a/eel/tests/rapid_gossip_sync_test.rs
+++ b/eel/tests/rapid_gossip_sync_test.rs
@@ -37,7 +37,7 @@ mod rapid_gossip_sync_test {
             nigiri::issue_invoice(NodeInstance::NigiriCln, "test", ONE_K_SATS, 3600).unwrap();
 
         {
-            let node = node_handle.start().unwrap();
+            let node = node_handle.start_or_panic();
             let lipa_node_id = node.get_node_info().node_pubkey.to_hex();
             wait_for_eq!(node.get_node_info().num_peers, 1);
 
@@ -106,7 +106,7 @@ mod rapid_gossip_sync_test {
         sleep(Duration::from_secs(5));
 
         {
-            let node = node_handle.start().unwrap();
+            let node = node_handle.start_or_panic();
 
             // Wait for p2p connection to be reestablished and channels marked active
             sleep(Duration::from_secs(5));
@@ -144,7 +144,7 @@ mod rapid_gossip_sync_test {
         sleep(Duration::from_secs(5));
 
         {
-            let node = node_handle.start().unwrap();
+            let node = node_handle.start_or_panic();
 
             // Wait for p2p connection to be reestablished and channels marked active
             sleep(Duration::from_secs(5));

--- a/eel/tests/receiving_payments_test.rs
+++ b/eel/tests/receiving_payments_test.rs
@@ -37,7 +37,7 @@ mod receiving_payments_test {
         let node_handle = mocked_storage_node();
 
         {
-            let node = node_handle.start().unwrap();
+            let node = node_handle.start_or_panic();
             wait_for_eq!(node.get_node_info().num_peers, 1);
 
             let lspd_node_id = nigiri::query_node_info(NodeInstance::LspdLnd)
@@ -64,7 +64,7 @@ mod receiving_payments_test {
         sleep(Duration::from_secs(5));
 
         {
-            let node = node_handle.start().unwrap();
+            let node = node_handle.start_or_panic();
 
             // Wait for p2p connection to be reestablished and channels marked active
             sleep(Duration::from_secs(5));
@@ -82,7 +82,7 @@ mod receiving_payments_test {
         sleep(Duration::from_secs(5));
 
         {
-            let node = node_handle.start().unwrap();
+            let node = node_handle.start_or_panic();
 
             // Wait for p2p connection to be reestablished and channels marked active
             sleep(Duration::from_secs(5));
@@ -124,7 +124,7 @@ mod receiving_payments_test {
     fn receive_multiple_payments_for_same_invoice() {
         nigiri::ensure_environment_running();
 
-        let node = mocked_storage_node().start().unwrap();
+        let node = mocked_storage_node().start_or_panic();
         let lipa_node_id = node.get_node_info().node_pubkey.to_hex();
         wait_for_eq!(node.get_node_info().num_peers, 1);
 

--- a/eel/tests/sending_payments_test.rs
+++ b/eel/tests/sending_payments_test.rs
@@ -21,7 +21,7 @@ mod sending_payments_test {
     #[file_serial(key, "/tmp/3l-int-tests-lock")]
     fn pay_invoice_direct_peer_test_and_invoice_decoding_test() {
         nigiri::setup_environment_with_lsp();
-        let node = mocked_storage_node().start().unwrap();
+        let node = mocked_storage_node().start_or_panic();
 
         wait_for_eq!(node.get_node_info().num_peers, 1);
         nigiri::initiate_channel_from_remote(node.get_node_info().node_pubkey, LspdLnd);

--- a/eel/tests/setup/mod.rs
+++ b/eel/tests/setup/mod.rs
@@ -34,6 +34,7 @@ impl<S: RemoteStorage + Clone + 'static> NodeHandle<S> {
     }
 
     pub fn start(&self) -> eel::errors::Result<LightningNode> {
+        log::debug!("Starting eel node ...");
         let events_handler = PrintEventsHandler {};
 
         LightningNode::new(
@@ -42,6 +43,13 @@ impl<S: RemoteStorage + Clone + 'static> NodeHandle<S> {
             Box::new(events_handler),
             Box::new(ExchangeRateProviderMock {}),
         )
+    }
+
+    pub fn start_or_panic(&self) -> LightningNode {
+        let node = self.start();
+        log::debug!("Eel node started");
+
+        node.unwrap()
     }
 
     pub fn get_storage(&mut self) -> &mut S {

--- a/eel/tests/setup/mod.rs
+++ b/eel/tests/setup/mod.rs
@@ -12,6 +12,7 @@ use mocked_remote_storage::MockedRemoteStorage;
 use print_events_handler::PrintEventsHandler;
 use std::fs;
 use std::sync::Arc;
+use std::time::Instant;
 use storage_mock::Storage;
 
 #[allow(dead_code)]
@@ -46,8 +47,14 @@ impl<S: RemoteStorage + Clone + 'static> NodeHandle<S> {
     }
 
     pub fn start_or_panic(&self) -> LightningNode {
+        let start = Instant::now();
         let node = self.start();
-        log::debug!("Eel node started");
+
+        let end = Instant::now();
+        log::debug!(
+            "Eel node started. Elapsed time: {:?}",
+            end.duration_since(start)
+        );
 
         node.unwrap()
     }


### PR DESCRIPTION
Starting the lightning node is a heavy task.
This PR adds some logging to make explicit whether that task could be completed or not.