### PR TITLE
Fix flaky test case

### DIFF
--- a/eel/tests/chain_sync_test.rs
+++ b/eel/tests/chain_sync_test.rs
@@ -130,10 +130,8 @@ mod chain_sync_test {
 
         let node = node_handle.start_or_panic();
 
-        sleep(Duration::from_secs(10));
-
-        // This only passes with the sleep that precedes it. TODO: confirm that's not a problem
-        assert_eq!(node.get_node_info().channels_info.num_channels, 0);
+        // Wait for the local node to learn that the channel has been force closed (esplora sync)
+        wait_for_eq!(node.get_node_info().channels_info.num_channels, 0);
     }
 
     fn start_node_open_channel_without_confirm_stop_node<S: RemoteStorage + Clone + 'static>(


### PR DESCRIPTION
This hopefully helps to make the test case `test_force_close_is_detected_offline_node_unconfirmed_channel` not [fail](https://github.com/getlipa/lipa-lightning-lib/actions/runs/4795261266/jobs/8529599143) every now and then.