### PR TITLE
Give LND the time it needs to sync its new channel

### DIFF
--- a/eel/tests/setup_env/mod.rs
+++ b/eel/tests/setup_env/mod.rs
@@ -745,7 +745,7 @@ pub mod nigiri {
             ) {
                 if pubkey.eq(target_node_id) && active {
                     // Wait a bit to avoid insufficient balance errors
-                    sleep(Duration::from_secs(1));
+                    sleep(Duration::from_secs(2));
                     return true;
                 }
             }


### PR DESCRIPTION
Since commit https://github.com/getlipa/lipa-lightning-lib/commit/07abb35c3dedae147211ddebed92d08d73201e05 which reduced the polling of waiting for channels to be ready from 500ms to 100ms, the following error has increasingly popped up in the CI: https://github.com/getlipa/lipa-lightning-lib/actions/runs/4881015403/jobs/8718631466?pr=354

This is a quick attempt to at least reduce the probability of the error happening.