### PR TITLE
Move getting outbound capacity to int test setup

### DIFF
--- a/eel/tests/p2p_connection_test.rs
+++ b/eel/tests/p2p_connection_test.rs
@@ -10,7 +10,6 @@ mod p2p_connection_test {
     use serial_test::file_parallel;
     use serial_test::file_serial;
     use std::thread::sleep;
-    use std::time::Duration;
 
     use crate::setup::mocked_storage_node;
     use crate::setup_env::nigiri;

--- a/eel/tests/setup_env/mod.rs
+++ b/eel/tests/setup_env/mod.rs
@@ -58,7 +58,7 @@ macro_rules! wait_for_condition {
     ($cond:expr, $message_if_not_satisfied:expr) => {
         (|| {
             let attempts = 1100;
-            let sleep_duration = Duration::from_millis(100);
+            let sleep_duration = std::time::Duration::from_millis(100);
             for _ in 0..attempts {
                 if $cond {
                     return;

--- a/tests/setup_3l/mod.rs
+++ b/tests/setup_3l/mod.rs
@@ -5,7 +5,6 @@ use uniffi_lipalightninglib::LightningNode;
 use uniffi_lipalightninglib::{recover_lightning_node, Config};
 
 use crate::wait_for_eq;
-use core::time::Duration;
 use eel::config::TzConfig;
 use eel::errors::RuntimeErrorCode;
 use std::env;


### PR DESCRIPTION
Setting up a node that is ready to send payments will be used in more than one test case. The code must therefore be reusable.