### PR TITLE
Swap payment hash and preimage for `payment_sent()` callback

### DIFF
--- a/eel/src/event_handler.rs
+++ b/eel/src/event_handler.rs
@@ -184,8 +184,8 @@ impl EventHandler for LipaEventHandler {
                     error!("Failed to persist in the payment db that sending payment with hash {} has succeeded", payment_hash.0.to_hex());
                 }
                 self.user_event_handler.payment_sent(
-                    payment_preimage.0.to_hex(),
                     payment_hash.0.to_hex(),
+                    payment_preimage.0.to_hex(),
                     fee_paid_msat,
                 );
             }


### PR DESCRIPTION
Tested manually with `make run-3l`