### PR TITLE
Make origin of channel size apparent

### DIFF
--- a/eel/tests/setup/mod.rs
+++ b/eel/tests/setup/mod.rs
@@ -4,9 +4,9 @@ pub mod mocked_remote_storage;
 mod print_events_handler;
 
 use crate::setup_env::config::get_testing_config;
-use crate::setup_env::nigiri;
 use crate::setup_env::nigiri::NodeInstance;
 use crate::setup_env::nigiri::NodeInstance::LspdLnd;
+use crate::setup_env::{nigiri, CHANNEL_SIZE_MSAT};
 use crate::wait_for_eq;
 use eel::config::Config;
 use eel::interfaces::{ExchangeRateProvider, RemoteStorage};
@@ -23,7 +23,6 @@ use storage_mock::Storage;
 const LSPD_LND_HOST: &str = "lspd-lnd";
 const LSPD_LND_PORT: u16 = 9739;
 const REBALANCE_AMOUNT: u64 = 50_000_000; // Msats to be sent to the Lipa node to generate outbound capacity
-const CHANNEL_SIZE: u64 = 1_000_000_000; // The capacity of the channel opened by the LSP: See https://github.com/getlipa/lipa-lightning-lib/blob/5657ff45fdf0c45065025d4ff9cb4ab97a32e9f3/lspd/compose.yaml#L54
 
 #[allow(dead_code)]
 pub struct NodeHandle<S: RemoteStorage + Clone + 'static> {
@@ -105,7 +104,8 @@ pub fn setup_outbound_capacity(node: &LightningNode) {
     );
     assert!(node.get_node_info().channels_info.outbound_capacity_msat < REBALANCE_AMOUNT); // because of channel reserves
     assert!(
-        node.get_node_info().channels_info.inbound_capacity_msat < CHANNEL_SIZE - REBALANCE_AMOUNT
+        node.get_node_info().channels_info.inbound_capacity_msat
+            < CHANNEL_SIZE_MSAT - REBALANCE_AMOUNT
     ); // smaller instead of equal because of channel reserves
 }
 

--- a/eel/tests/setup_env/mod.rs
+++ b/eel/tests/setup_env/mod.rs
@@ -10,6 +10,7 @@ use simplelog::{ConfigBuilder, LevelFilter, SimpleLogger};
 use std::sync::Once;
 
 static INIT_LOGGER_ONCE: Once = Once::new();
+pub const CHANNEL_SIZE_MSAT: u64 = 1_000_000_000;
 
 #[ctor::ctor]
 fn init_logger() {
@@ -464,7 +465,8 @@ pub mod nigiri {
         zero_conf: bool,
         private: bool,
     ) -> Result<String, String> {
-        let mut sub_cmd = vec!["openchannel", target_node_id, "1000000"];
+        let channel_size = (CHANNEL_SIZE_MSAT / 1_000).to_string();
+        let mut sub_cmd = vec!["openchannel", target_node_id, &channel_size];
 
         if private {
             sub_cmd.insert(1, "--private");
@@ -508,7 +510,8 @@ pub mod nigiri {
         node: NodeInstance,
         target_node_id: &str,
     ) -> Result<String, String> {
-        let sub_cmd = vec!["fundchannel", target_node_id, "1000000"];
+        let channel_size = (CHANNEL_SIZE_MSAT / 1_000).to_string();
+        let sub_cmd = vec!["fundchannel", target_node_id, &channel_size];
         let cmd = [get_node_prefix(node), &sub_cmd].concat();
 
         let output = exec(cmd.as_slice());


### PR DESCRIPTION
Fix semantics in integration tests: The channel size is not being determined by `lspd` but is actually just an arbitrary value defined in the integration tests themselves.