### PR TITLE
Enable backtrace and debug symbols for our and LDK crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,31 @@ pre-build = ["apt update --no-show-upgraded && apt install --yes protobuf-compil
 [build-dependencies]
 camino = "1.1.1"
 uniffi_bindgen = "0.23.0"
+
+# Enable debug symbols for our and LDK crates, but not others.
+[profile.release]
+debug = 1
+[profile.release.package."*"]
+debug = 0
+[profile.release.package.eel]
+debug = 1
+[profile.release.package.chameleon]
+debug = 1
+[profile.release.package.honey-badger]
+debug = 1
+[profile.release.package.mole]
+debug = 1
+[profile.release.package.lightning]
+debug = 1
+[profile.release.package.lightning-background-processor]
+debug = 1
+[profile.release.package.lightning-invoice]
+debug = 1
+[profile.release.package.lightning-net-tokio]
+debug = 1
+[profile.release.package.lightning-persister]
+debug = 1
+[profile.release.package.lightning-rapid-gossip-sync]
+debug = 1
+[profile.release.package.lightning-transaction-sync]
+debug = 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,8 @@ use honey_badger::secrets::{generate_keypair, KeyPair};
 use honey_badger::{Auth, AuthLevel};
 use native_logger::init_native_logger_once;
 use perro::{MapToError, ResultTrait};
-use std::fs;
 use std::sync::Arc;
+use std::{env, fs};
 
 const BACKEND_AUTH_DERIVATION_PATH: &str = "m/76738065'/0'/0";
 
@@ -96,6 +96,7 @@ pub struct LightningNode {
 
 impl LightningNode {
     pub fn new(config: Config, events_callback: Box<dyn EventsCallback>) -> Result<Self> {
+        enable_backtrace();
         fs::create_dir_all(&config.local_persistence_path).map_to_permanent_failure(format!(
             "Failed to create directory: {}",
             config.local_persistence_path,
@@ -272,6 +273,7 @@ impl LightningNode {
 }
 
 pub fn accept_terms_and_conditions(environment: EnvironmentCode, seed: Vec<u8>) -> Result<()> {
+    enable_backtrace();
     let environment = Environment::load(environment);
     let seed = sanitize_input::strong_type_seed(&seed)?;
     let auth = build_auth(&seed, environment.backend_url)?;
@@ -342,6 +344,10 @@ fn to_limits(
         max_receive: limits.max_receive_msat.to_amount_down(rate),
         liquidity_limit,
     }
+}
+
+pub(crate) fn enable_backtrace() {
+    env::set_var("RUST_BACKTRACE", "1");
 }
 
 include!(concat!(env!("OUT_DIR"), "/lipalightninglib.uniffi.rs"));

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -1,6 +1,6 @@
 use crate::eel_interface_impl::RemoteStorageGraphql;
 use crate::environment::Environment;
-use crate::{build_auth, sanitize_input, EnvironmentCode};
+use crate::{build_auth, enable_backtrace, sanitize_input, EnvironmentCode};
 use eel::errors::Result;
 use perro::MapToError;
 use std::fs;
@@ -11,6 +11,7 @@ pub fn recover_lightning_node(
     seed: Vec<u8>,
     local_persistence_path: String,
 ) -> Result<()> {
+    enable_backtrace();
     fs::create_dir_all(&local_persistence_path).map_to_permanent_failure(format!(
         "Failed to create directory: {}",
         local_persistence_path,


### PR DESCRIPTION
It increases the size of 3l-node example node from 28M to 81M.