### PR TITLE
Add network to `InvoiceDetails`

### DIFF
--- a/eel/src/invoice.rs
+++ b/eel/src/invoice.rs
@@ -60,7 +60,7 @@ pub(crate) fn validate_invoice(network: Network, invoice: &Invoice) -> Result<()
     Ok(())
 }
 
-fn network_from_currency(currency: Currency) -> Network {
+pub fn network_from_currency(currency: Currency) -> Network {
     match currency {
         Currency::Bitcoin => Network::Bitcoin,
         Currency::BitcoinTestnet => Network::Testnet,

--- a/eel/src/lib.rs
+++ b/eel/src/lib.rs
@@ -3,30 +3,30 @@
 extern crate core;
 
 pub mod config;
-mod data_store;
 pub mod errors;
 pub mod interfaces;
+pub mod invoice;
 pub mod key_derivation;
 pub mod keys_manager;
 pub mod limits;
 pub mod lsp;
-mod migrations;
 pub mod node_info;
 pub mod p2p_networking;
 pub mod payment;
 pub mod recovery;
-mod schema_migration;
 pub mod secret;
 
 mod async_runtime;
+mod data_store;
 mod encryption_symmetric;
 mod esplora_client;
 mod event_handler;
 mod fee_estimator;
-mod invoice;
 mod logger;
+mod migrations;
 mod random;
 mod rapid_sync_client;
+mod schema_migration;
 mod storage_persister;
 mod task_manager;
 mod test_utils;

--- a/src/invoice_details.rs
+++ b/src/invoice_details.rs
@@ -1,7 +1,8 @@
 use crate::amount::{Amount, ToAmount};
 
 use eel::interfaces::ExchangeRate;
-use eel::{Invoice, InvoiceDescription};
+use eel::invoice::network_from_currency;
+use eel::{Invoice, InvoiceDescription, Network};
 use std::time::{Duration, SystemTime};
 
 pub struct InvoiceDetails {
@@ -13,6 +14,7 @@ pub struct InvoiceDetails {
     pub creation_timestamp: SystemTime,
     pub expiry_interval: Duration,
     pub expiry_timestamp: SystemTime,
+    pub network: Network,
 }
 
 impl InvoiceDetails {
@@ -42,6 +44,8 @@ fn to_invoice_details(invoice: Invoice, amount: Option<Amount>) -> InvoiceDetail
         Some(p) => p.to_string(),
     };
 
+    let network = network_from_currency(invoice.currency());
+
     InvoiceDetails {
         invoice: invoice.to_string(),
         amount,
@@ -51,6 +55,7 @@ fn to_invoice_details(invoice: Invoice, amount: Option<Amount>) -> InvoiceDetail
         creation_timestamp: invoice.timestamp(),
         expiry_interval: invoice.expiry_time(),
         expiry_timestamp: invoice.timestamp() + invoice.expiry_time(),
+        network,
     }
 }
 

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -263,6 +263,14 @@ dictionary InvoiceDetails {
     timestamp creation_timestamp; // The moment an invoice was created (UTC)
     duration expiry_interval; // The interval after which the invoice expires (creation_timestamp + expiry_interval = expiry_timestamp)
     timestamp expiry_timestamp; // The moment an invoice expires (UTC)
+    Network network; // The bitcoin network the invoice belongs to
+};
+
+enum Network {
+    "Bitcoin",
+    "Testnet",
+    "Signet",
+    "Regtest",
 };
 
 // Information about an incoming or outgoing payment


### PR DESCRIPTION
I realized there's no way for the consumer of 3L to fulfil the obligation of providing same network invoices to `LightningNode::pay_invoice()`. With these changes, the consumer can learn the network of an invoice when calling `LightningNode::decode_invoice()`.