### PR TITLE
Fix logging for lightning to log file and line number

### DIFF
--- a/eel/src/logger.rs
+++ b/eel/src/logger.rs
@@ -1,14 +1,17 @@
 use lightning::util::logger::{Level, Logger, Record};
-use log::{log, log_enabled};
+use log::log_enabled;
 
 pub struct LightningLogger;
 
 impl Logger for LightningLogger {
     fn log(&self, record: &Record) {
         let level = map_level(record.level);
-        if log_enabled!(level) {
-            let message = record.args.to_string();
-            log!(level, "[{}] {}", record.module_path, message);
+        if log_enabled!(target: record.module_path, level) {
+            let file = strip_prefix(record.file);
+            let location = (record.module_path, "", file, record.line);
+            // Using the internal function because log!() allows to provive
+            // target to override `module_path`, but not file nor line.
+            log::__private_api_log(record.args, level, &location, None);
         }
     }
 }
@@ -22,4 +25,9 @@ fn map_level(level: lightning::util::logger::Level) -> log::Level {
         Level::Warn => log::Level::Warn,
         Level::Error => log::Level::Error,
     }
+}
+
+fn strip_prefix(line: &'static str) -> &'static str {
+    let index = line.find("lightning").unwrap_or(0);
+    &line[index..]
 }


### PR DESCRIPTION
Before:
```
[TRACE] (14) eel::logger: [eel/src/logger.rs:11] [lightning_background_processor] Terminating background processor.
```
After:
```
[TRACE] (14) lightning_background_processor: [lightning-background-processor-0.0.115/src/lib.rs:773] Terminating background processor.
```