### PR TITLE
Increase payment timeout to 90 secs

### DIFF
--- a/eel/src/lib.rs
+++ b/eel/src/lib.rs
@@ -87,6 +87,8 @@ use std::thread::sleep;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tokio::time::Duration;
 
+const PAYMENT_TIMEOUT: Duration = Duration::from_secs(90);
+
 const FOREGROUND_PERIODS: TaskPeriods = TaskPeriods {
     sync_blockchain: Duration::from_secs(5 * 60),
     update_lsp_info: Some(PeriodConfig {
@@ -473,7 +475,7 @@ impl LightningNode {
         self.log_node_state();
         let payment_result = pay_invoice(
             &invoice,
-            Retry::Timeout(Duration::from_secs(15)),
+            Retry::Timeout(PAYMENT_TIMEOUT),
             &self.channel_manager,
         );
 
@@ -519,7 +521,7 @@ impl LightningNode {
         let payment_result = pay_zero_value_invoice(
             &invoice,
             amount_msat,
-            Retry::Timeout(Duration::from_secs(10)),
+            Retry::Timeout(PAYMENT_TIMEOUT),
             &self.channel_manager,
         );
 


### PR DESCRIPTION
When paying using MPP, if some of the parts reach the payee, but the others fail, payments will stay pending for a while. This is because the payee holds the HTLCs, waiting for the rest to arrive. This period is implementation dependent, but I've verified through experiments that for WoS is ~2 minutes. 

This made me realize it doesn't make any sense to keep the timeout low. By doing so, we are still subject to "long" pending times when the above scenario occurs, and even worse, we reduce the likelihood of payments being successful because we stopped retrying failed payment parts. 