### PR TITLE
Remove `bundled` feature of `rusqlite` for iOS target

### DIFF
--- a/eel/Cargo.toml
+++ b/eel/Cargo.toml
@@ -28,7 +28,6 @@ num_enum = "0.6.1"
 prost = "0.11.9"
 rand = "0.8.5"
 reqwest = { version = "0.11.18", default-features = false, features = ["blocking", "rustls-tls"] }
-rusqlite = { version = "0.29.0", features = ["bundled", "chrono"] }
 # Explicitly depend on secp256k1 for secp256k1::SECP256K1.
 secp256k1 = { version = "0.24.3", features = ["global-context"] }
 thiserror = "1.0.44"
@@ -36,6 +35,12 @@ tokio = { version = "1.29.1", features = ["rt-multi-thread", "time", "sync"] }
 tonic = "0.9.2"
 
 perro = { git = "https://github.com/getlipa/perro", tag = "v1.1.0" }
+
+# Bundle sqlite for all targets except iOS.
+[target.'cfg(not(target_os = "ios"))'.dependencies]
+rusqlite = { version = "0.29.0", features = ["bundled", "chrono"] }
+[target.'cfg(target_os = "ios")'.dependencies]
+rusqlite = { version = "0.29.0", features = ["chrono"] }
 
 [dev-dependencies]
 colored = "2.0.4"


### PR DESCRIPTION
`bundled` enables `modern_sqlite` feature (i.e. it uses the API of recent versions of SQLite). But iOS does not use the bundled version (maybe it doesn't get bundled for iOS) and iOS native version of SQLite is not very recent.