### PR TITLE
Fail recovery if a remote monitor is corrupted

### DIFF
--- a/eel/src/recovery.rs
+++ b/eel/src/recovery.rs
@@ -2,7 +2,7 @@ use crate::errors::Result;
 use crate::interfaces::RemoteStorage;
 use crate::key_derivation;
 use crate::keys_manager::init_keys_manager;
-use crate::storage_persister::{has_local_install, StoragePersister};
+use crate::storage_persister::{has_local_install, CorruptedMonitorPolicy, StoragePersister};
 use log::info;
 use perro::{invalid_input, MapToError};
 use std::fs;
@@ -38,8 +38,11 @@ pub fn recover_lightning_node(
     seed_first_half.copy_from_slice(&seed[..32]);
     let keys_manager = Arc::new(init_keys_manager(&seed_first_half)?);
 
-    let remote_channel_monitors =
-        storage.fetch_remote_channel_monitors(&*keys_manager, &*keys_manager)?;
+    let remote_channel_monitors = storage.fetch_remote_channel_monitors(
+        &*keys_manager,
+        &*keys_manager,
+        CorruptedMonitorPolicy::Fail,
+    )?;
     info!(
         "Fetched {} channel monitors from remote storage during recovery procedure",
         remote_channel_monitors.len()


### PR DESCRIPTION
It is unclear how a channel monitor would get corrupted, but assuming it happened, these are the scenarios that we should think about:

* Normal node start + remote backup was made by the same install:

    * It makes sense to ignore corrupted monitors and still start the node. Starting the node automatically persists all monitors again, so the issue is likely to be resolved → No changes required

* Normal node start + remote backup was made by a different install:

    * If we ignore corrupted monitors and no other monitor indicates that the state has moved forward, we will try to start the node, potentially causing some channel closes. AFAICT, there’s nothing we can do here. Failing the node start if we find a corrupted monitor wouldn’t help → No changes required

    * Also, the user shouldn’t go back to an old install after performing recovery on a new one

* Recovery start:

    * Failing the recovery if a remote monitor is corrupted could make sense. We could tell the user to start the old wallet install if it’s available. Otherwise, contact lipa. If we ignore it when recovering, the channel will be lost without any information being shown to the user → We should change the recovery to fail if a corrupted remote monitor is found