### PR TITLE
Show peer node-IDs in node_info()

### DIFF
--- a/eel/examples/eel-node/cli.rs
+++ b/eel/examples/eel-node/cli.rs
@@ -142,8 +142,20 @@ fn payment_amount_limits(node: &LightningNode) {
 
 fn node_info(node: &LightningNode) {
     let node_info = node.get_node_info();
+    let peers_list = if node_info.peers.is_empty() {
+        "None".to_string()
+    } else {
+        node_info
+            .peers
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<String>>()
+            .join(", ")
+    };
+
     println!("Node PubKey: {}", node_info.node_pubkey);
-    println!(" Number of connected peers: {}", node_info.num_peers);
+    println!("Connected peer(s): {}", peers_list);
+
     println!(
         "       Number of channels: {}",
         node_info.channels_info.num_channels

--- a/eel/src/lib.rs
+++ b/eel/src/lib.rs
@@ -376,10 +376,17 @@ impl LightningNode {
     }
 
     pub fn get_node_info(&self) -> NodeInfo {
+        let peer_pubkeys = self
+            .peer_manager
+            .get_peer_node_ids()
+            .iter()
+            .map(|p| p.0)
+            .collect();
+
         let channels_info = get_channels_info(&self.channel_manager.list_channels());
         NodeInfo {
             node_pubkey: self.channel_manager.get_our_node_id(),
-            num_peers: self.peer_manager.get_peer_node_ids().len() as u16,
+            peers: peer_pubkeys,
             channels_info,
         }
     }
@@ -821,14 +828,14 @@ impl LightningNode {
 
         trace!(
             "Logging node state...\n\
-            Number of connected peers: {}\n\
+            Connected peers: {:?}\n\
             Number of channels: {}\n\
             Number of usable channels: {}\n\
             Local balance msat: {}\n\
             Inbound capacity msat: {}\n\
             Outbound capacity msat: {}\n\
             Capacity of all channels msat: {}",
-            node_info.num_peers,
+            node_info.peers,
             node_info.channels_info.num_channels,
             node_info.channels_info.num_usable_channels,
             node_info.channels_info.local_balance_msat,

--- a/eel/src/node_info.rs
+++ b/eel/src/node_info.rs
@@ -14,7 +14,7 @@ pub struct ChannelsInfo {
 #[derive(Debug, PartialEq, Eq)]
 pub struct NodeInfo {
     pub node_pubkey: PublicKey,
-    pub num_peers: u16,
+    pub peers: Vec<PublicKey>,
     pub channels_info: ChannelsInfo,
 }
 

--- a/eel/tests/data_store_test.rs
+++ b/eel/tests/data_store_test.rs
@@ -34,7 +34,7 @@ mod data_store_test {
 
         {
             let node = node_handle.start_or_panic();
-            wait_for_eq!(node.get_node_info().num_peers, 1);
+            wait_for!(!node.get_node_info().peers.is_empty());
 
             let lspd_node_id = nigiri::query_node_info(NodeInstance::LspdLnd)
                 .unwrap()

--- a/eel/tests/p2p_connection_test.rs
+++ b/eel/tests/p2p_connection_test.rs
@@ -14,7 +14,7 @@ mod p2p_connection_test {
     use crate::setup::mocked_storage_node;
     use crate::setup_env::nigiri;
     use crate::setup_env::nigiri::NodeInstance;
-    use crate::{wait_for_eq, wait_for_ok};
+    use crate::{wait_for, wait_for_ok};
 
     #[test]
     #[file_parallel(key, "/tmp/3l-int-tests-lock")]
@@ -22,7 +22,7 @@ mod p2p_connection_test {
         nigiri::ensure_environment_running();
         let node = mocked_storage_node().start_or_panic();
 
-        wait_for_eq!(node.get_node_info().num_peers, 1);
+        wait_for!(!node.get_node_info().peers.is_empty());
         let peers = nigiri::list_peers(NodeInstance::LspdLnd).unwrap();
         assert!(peers.contains(&node.get_node_info().node_pubkey.to_hex()));
     }
@@ -41,13 +41,13 @@ mod p2p_connection_test {
                 "Failed to get LSP info"
             ))
         );
-        assert_eq!(node.get_node_info().num_peers, 0);
+        assert!(node.get_node_info().peers.is_empty());
 
         // Test reconnect when LSP is back.
         nigiri::start_lspd();
         nigiri::ensure_environment_running();
         nigiri::wait_for_healthy_lspd();
-        wait_for_eq!(node.get_node_info().num_peers, 1);
+        wait_for!(!node.get_node_info().peers.is_empty());
         let peers = nigiri::list_peers(NodeInstance::LspdLnd).unwrap();
         assert!(peers.contains(&node.get_node_info().node_pubkey.to_hex()));
         wait_for_ok!(node.query_lsp_fee());

--- a/eel/tests/persistence_test.rs
+++ b/eel/tests/persistence_test.rs
@@ -120,7 +120,7 @@ mod persistence_test {
     ) {
         {
             let node = node_handle.start_or_panic();
-            wait_for_eq!(node.get_node_info().num_peers, 1);
+            wait_for!(!node.get_node_info().peers.is_empty());
 
             let lspd_node_id = nigiri::query_node_info(NodeInstance::LspdLnd)
                 .unwrap()

--- a/eel/tests/rapid_gossip_sync_test.rs
+++ b/eel/tests/rapid_gossip_sync_test.rs
@@ -40,7 +40,7 @@ mod rapid_gossip_sync_test {
         {
             let node = node_handle.start_or_panic();
             let lipa_node_id = node.get_node_info().node_pubkey.to_hex();
-            wait_for_eq!(node.get_node_info().num_peers, 1);
+            wait_for!(!node.get_node_info().peers.is_empty());
 
             // Setup channels:
             // NigiriLND -> LspdLnd  -> 3L

--- a/eel/tests/receiving_payments_test.rs
+++ b/eel/tests/receiving_payments_test.rs
@@ -46,7 +46,7 @@ mod receiving_payments_test {
 
         {
             let node = node_handle.start_or_panic();
-            wait_for_eq!(node.get_node_info().num_peers, 1);
+            wait_for!(!node.get_node_info().peers.is_empty());
 
             let lspd_node_id = nigiri::query_node_info(NodeInstance::LspdLnd)
                 .unwrap()
@@ -201,7 +201,7 @@ mod receiving_payments_test {
 
         let node = mocked_storage_node().start_or_panic();
         let lipa_node_id = node.get_node_info().node_pubkey.to_hex();
-        wait_for_eq!(node.get_node_info().num_peers, 1);
+        wait_for!(!node.get_node_info().peers.is_empty());
 
         let lspd_node_id = nigiri::query_node_info(NodeInstance::LspdLnd)
             .unwrap()

--- a/eel/tests/setup/mod.rs
+++ b/eel/tests/setup/mod.rs
@@ -7,7 +7,7 @@ use crate::setup_env::config::get_testing_config;
 use crate::setup_env::nigiri::NodeInstance;
 use crate::setup_env::nigiri::NodeInstance::LspdLnd;
 use crate::setup_env::{nigiri, CHANNEL_SIZE_MSAT};
-use crate::wait_for_eq;
+use crate::wait_for;
 
 use eel::config::Config;
 use eel::errors::{InternalResult, InternalRuntimeErrorCode};
@@ -93,7 +93,7 @@ impl<S: RemoteStorage + Clone + 'static, X: ExchangeRateProvider + Clone> NodeHa
 
 #[allow(dead_code)]
 pub fn setup_outbound_capacity(node: &LightningNode) -> String {
-    wait_for_eq!(node.get_node_info().num_peers, 1);
+    wait_for!(!node.get_node_info().peers.is_empty());
     let funding_txid =
         nigiri::initiate_channel_from_remote(node.get_node_info().node_pubkey, LspdLnd);
 

--- a/examples/3l-node/cli.rs
+++ b/examples/3l-node/cli.rs
@@ -286,11 +286,22 @@ fn payment_amount_limits(node: &LightningNode) {
 
 fn node_info(node: &LightningNode) {
     let node_info = node.get_node_info();
+    let peers_list = if node_info.peers.is_empty() {
+        "None".to_string()
+    } else {
+        node_info
+            .peers
+            .iter()
+            .map(|p| PublicKey::from_slice(p).unwrap().to_string())
+            .collect::<Vec<String>>()
+            .join(", ")
+    };
+
     println!(
         "Node PubKey: {}",
         PublicKey::from_slice(&node_info.node_pubkey).unwrap()
     );
-    println!("Number of connected peers: {}", node_info.num_peers);
+    println!("Connected peer(s): {}", peers_list);
     println!(
         "       Number of channels: {}",
         node_info.channels_info.num_channels

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ pub struct LspFee {
 
 pub struct NodeInfo {
     pub node_pubkey: Vec<u8>,
-    pub num_peers: u16,
+    pub peers: Vec<Vec<u8>>,
     pub channels_info: ChannelsInfo,
 }
 
@@ -218,9 +218,14 @@ impl LightningNode {
             inbound_capacity: channels.inbound_capacity_msat.to_amount_down(&rate),
             outbound_capacity: channels.outbound_capacity_msat.to_amount_down(&rate),
         };
+
         NodeInfo {
             node_pubkey: node.node_pubkey.serialize().to_vec(),
-            num_peers: node.num_peers,
+            peers: node
+                .peers
+                .iter()
+                .map(|peer| peer.serialize().to_vec())
+                .collect(),
             channels_info,
         }
     }

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -243,7 +243,7 @@ callback interface EventsCallback {
 // Information about the Lightning node running in the background
 dictionary NodeInfo {
     bytes node_pubkey; // Lightning network public key of the node (also known as node id)
-    u16 num_peers; // Number of peers the node is connected to
+    sequence<bytes> peers; // List of node ids of all the peers the node is connected to
     ChannelsInfo channels_info; // Information about the channels of the node
 };
 

--- a/tests/remote_persistence_test.rs
+++ b/tests/remote_persistence_test.rs
@@ -30,7 +30,7 @@ mod remote_persistence_test {
             let node = node_handle.start().unwrap();
             let node_info = node.get_node_info();
             let node_id = node_info.node_pubkey.to_hex();
-            assert_eq!(node_info.num_peers, 1);
+            assert_eq!(node_info.peers.len(), 1);
 
             // open 2 channels
             nigiri::lnd_node_open_channel(NodeInstance::LspdLnd, &node_id, false).unwrap();

--- a/tests/setup_3l/mod.rs
+++ b/tests/setup_3l/mod.rs
@@ -4,7 +4,7 @@ use crate::setup_env::config::{get_testing_config, LOCAL_PERSISTENCE_PATH};
 use uniffi_lipalightninglib::{recover_lightning_node, Config};
 use uniffi_lipalightninglib::{LightningNode, RuntimeErrorCode};
 
-use crate::wait_for_eq;
+use crate::wait_for;
 use eel::config::TzConfig;
 use std::fs;
 
@@ -44,7 +44,7 @@ impl NodeHandle {
         let node = LightningNode::new(self.config.clone(), Box::new(events_handler))?;
 
         // Wait for the the P2P background task to connect to the LSP
-        wait_for_eq!(node.get_node_info().num_peers, 1);
+        wait_for!(!node.get_node_info().peers.is_empty());
 
         Ok(node)
     }


### PR DESCRIPTION
This changes the UDL interface and is a breaking change.
Number of peers isn't shown explicitly anymore, but can implicitly be derived from the list length.