### PR TITLE
Expose `ExchangeRate` for Pocket offer rather than `FiatValue`

### DIFF
--- a/examples/3l-node/cli.rs
+++ b/examples/3l-node/cli.rs
@@ -561,22 +561,30 @@ fn list_offers(node: &LightningNode) -> Result<(), String> {
         match offer.offer_kind {
             OfferKind::Pocket {
                 id,
-                topup_value,
-                exchange_fee,
+                exchange_rate,
+                topup_value_minor_units,
+                exchange_fee_minor_units,
                 exchange_fee_rate_permyriad,
             } => {
                 println!("                   ID:    {id}");
                 println!(
-                    "      Value exchanged:    {}",
-                    fiat_value_to_string(topup_value)
+                    "      Value exchanged:    {:.2} {}",
+                    topup_value_minor_units as f64 / 100f64,
+                    exchange_rate.currency_code,
                 );
                 println!(
                     "      Exchange fee rate:  {}%",
                     exchange_fee_rate_permyriad as f64 / 100_f64
                 );
                 println!(
-                    "      Exchange fee value: {}",
-                    fiat_value_to_string(exchange_fee)
+                    "      Exchange fee value: {:.2} {}",
+                    exchange_fee_minor_units as f64 / 100f64,
+                    exchange_rate.currency_code,
+                );
+                let exchanged_at: DateTime<Utc> = exchange_rate.updated_at.into();
+                println!(
+                    "             Exchange at: {}",
+                    exchanged_at.format("%d/%m/%Y %T UTC"),
                 );
             }
         }

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -411,8 +411,10 @@ dictionary OfferInfo {
 interface OfferKind {
     Pocket(
         string id,
-        FiatValue topup_value, // The original fiat amount sent to the exchange
-        FiatValue exchange_fee, // The fee paid to perform the exchange from fiat to sats
+        // Fiat currency is the currency the user sent to the exchange.
+        ExchangeRate exchange_rate, // The exchange rate used by the exchange to exchange fiat to sats
+        u64 topup_value_minor_units, // The original fiat amount sent to the exchange
+        u64 exchange_fee_minor_units, // The fee paid to perform the exchange from fiat to sats
         u16 exchange_fee_rate_permyriad // The rate of the fee expressed in permyriad (e.g. 1.5% would be 150)
     );
 };


### PR DESCRIPTION
It makes more sense since the fiat value was not exchanged *from* sats. Also it will simplify the persistance of offers.