### PR TITLE
Upgrade gradle

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -293,14 +293,10 @@ jobs:
           
           cp ../bindings/kotlin/uniffi/lipalightninglib/lipalightninglib.kt LipaLightningLib/src/main/java/com/getlipa/lipalightninglib/lipalightninglib.kt
           
-          mkdir -p jniLibs/arm64
           mkdir -p jniLibs/arm64-v8a
-          mkdir -p jniLibs/armeabi
           mkdir -p jniLibs/armeabi-v7a
           mkdir -p jniLibs/x86
-          cp ../target/aarch64-linux-android/release/libuniffi_lipalightninglib.so jniLibs/arm64
           cp ../target/aarch64-linux-android/release/libuniffi_lipalightninglib.so jniLibs/arm64-v8a
-          cp ../target/armv7-linux-androideabi/release/libuniffi_lipalightninglib.so jniLibs/armeabi
           cp ../target/armv7-linux-androideabi/release/libuniffi_lipalightninglib.so jniLibs/armeabi-v7a
           cp ../target/i686-linux-android/release/libuniffi_lipalightninglib.so jniLibs/x86
           zip -r jniLibs.zip jniLibs


### PR DESCRIPTION
(same as #631) but for the Breez SDK branch

This change is related to the gradle upgrade of the android lib project in https://github.com/getlipa/lipa-lightning-lib-android/pull/7

Once @fjuzen tests the android app of a test release that includes these changes, we should be ready to merge