### PR TITLE
Implement `lock_unwrap()` trait for `Mutex`

### DIFF
--- a/src/locker.rs
+++ b/src/locker.rs
@@ -1,0 +1,11 @@
+use std::sync::{Mutex, MutexGuard};
+
+pub(crate) trait Locker<T> {
+    fn lock_unwrap(&self) -> MutexGuard<'_, T>;
+}
+
+impl<T> Locker<T> for Mutex<T> {
+    fn lock_unwrap(&self) -> MutexGuard<'_, T> {
+        self.lock().unwrap()
+    }
+}


### PR DESCRIPTION
I noticed the pattern for mutexes that we often call `lock().unwrap()`.
Such simplification makes code shorter and easier to grep for `unwrap()`s.