### PR TITLE
Fix maxfee_percent integer division

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,7 +281,7 @@ impl LightningNode {
 
         breez_config.working_dir = config.local_persistence_path.clone();
         // TODO configure `exemptfee` when exposed by Breez
-        breez_config.maxfee_percent = (MAX_FEE_PERMYRIAD / 100).into();
+        breez_config.maxfee_percent = MAX_FEE_PERMYRIAD as f64 / 100_f64;
 
         let sdk = rt
             .handle()


### PR DESCRIPTION
Seems like we were providing a max fee percentage of 0% to the SDK. I found this while trying to debug the pathfinding problems, but this fix doesn't seem to help.