### PR TITLE
Reduce binary sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,14 +70,10 @@ strip-ansi-escapes = "0.2.0"
 camino = "1.1.6"
 uniffi_bindgen = "0.24.0"
 
-# Enable debug symbols for our and Breez crates, but not others.
+# Use some of the binary size reduction strategies from https://github.com/johnthagen/min-sized-rust
 [profile.release]
-debug = 1
-[profile.release.package."*"]
-debug = 0
-[profile.release.package.chameleon]
-debug = 1
-[profile.release.package.honey-badger]
-debug = 1
-[profile.release.package.breez-sdk-core]
-debug = 1
+strip = true
+opt-level = "z"
+lto = true
+codegen-units = 1
+panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,4 +76,3 @@ strip = true
 opt-level = "z"
 lto = true
 codegen-units = 1
-panic = "abort"


### PR DESCRIPTION
This reduces the shared library `.so` binary for `aarch64-linux-android` from >80 MB to <20 MB