### PR TITLE
Persist created invoices

### DIFF
--- a/src/amount.rs
+++ b/src/amount.rs
@@ -44,7 +44,7 @@ impl AsSats for u32 {
 }
 
 /// A fiat value accompanied by the exchange rate that was used to get it.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct FiatValue {
     /// Fiat amount denominated in the currencies' minor units. For most fiat currencies, the minor unit is the cent.
     pub minor_units: u64,
@@ -55,7 +55,7 @@ pub struct FiatValue {
 }
 
 /// A sat amount accompanied by its fiat value in a specific fiat currency
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Amount {
     pub sats: u64,
     pub fiat: Option<FiatValue>,

--- a/src/invoice_details.rs
+++ b/src/invoice_details.rs
@@ -6,7 +6,7 @@ use breez_sdk_core::LNInvoice;
 use std::time::{Duration, SystemTime};
 
 /// Information embedded in an invoice
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct InvoiceDetails {
     /// The BOLT-11 invoice.
     pub invoice: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -901,7 +901,7 @@ impl LightningNode {
         {
             self.payment_from_created_invoice(&invoice)
         } else {
-            return Err(invalid_input("No payment with provided hash was found"));
+            invalid_input!("No payment with provided hash was found");
         }
     }
 

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -56,7 +56,7 @@ const MIGRATION_03_OFFER_ERROR_MESSAGE: &str = "
 
 const MIGRATION_04_CREATED_INVOICES: &str = "
     CREATE TABLE created_invoices (
-        hash TEXT NOT NULL PRIMARY KEY,
+        id INTEGER NOT NULL PRIMARY KEY,
         invoice TEXT NOT NULL
     );
 ";

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -53,6 +53,14 @@ const MIGRATION_02_FUNDS_MIGRATION_STATUS: &str = "
 const MIGRATION_03_OFFER_ERROR_MESSAGE: &str = "
     ALTER TABLE offers ADD COLUMN error TEXT NULL;
 ";
+
+const MIGRATION_04_CREATED_INVOICES: &str = "
+    CREATE TABLE created_invoices (
+        hash TEXT NOT NULL PRIMARY KEY,
+        invoice TEXT NOT NULL
+    );
+";
+
 pub(crate) fn migrate(conn: &mut Connection) -> Result<()> {
     migrations()
         .to_latest(conn)
@@ -64,6 +72,7 @@ fn migrations() -> Migrations<'static> {
         M::up(MIGRATION_01_INIT),
         M::up(MIGRATION_02_FUNDS_MIGRATION_STATUS),
         M::up(MIGRATION_03_OFFER_ERROR_MESSAGE),
+        M::up(MIGRATION_04_CREATED_INVOICES),
     ])
 }
 

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -57,6 +57,7 @@ const MIGRATION_03_OFFER_ERROR_MESSAGE: &str = "
 const MIGRATION_04_CREATED_INVOICES: &str = "
     CREATE TABLE created_invoices (
         id INTEGER NOT NULL PRIMARY KEY,
+        hash INTEGER NOT NULL,
         invoice TEXT NOT NULL
     );
 ";


### PR DESCRIPTION
This is an inefficient implementation, but I propose we go with it as a first step because:
* the low amount of payments we expect to have initially makes it unlikely that this implementation won't be performant enough
* the SDK plans on providing this data eventually