### PR TITLE
Increase total time span captured in logs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ use email_address::EmailAddress;
 use honey_badger::secrets::{generate_keypair, KeyPair};
 use honey_badger::{Auth, AuthLevel, CustomTermsAndConditions};
 use iban::Iban;
-use log::{info, trace};
+use log::{debug, info};
 use logger::init_logger_once;
 use perro::{
     invalid_input, permanent_failure, runtime_error, MapToError, OptionToError, ResultTrait,
@@ -101,7 +101,7 @@ use std::time::{Duration, SystemTime};
 use std::{env, fs};
 use uuid::Uuid;
 
-const LOG_LEVEL: log::Level = log::Level::Trace;
+const LOG_LEVEL: log::Level = log::Level::Debug;
 const LOGS_DIR: &str = "logs";
 
 pub(crate) const DB_FILENAME: &str = "db2.db3";
@@ -1171,7 +1171,7 @@ impl LightningNode {
         user_iban: String,
         user_currency: String,
     ) -> Result<FiatTopupInfo> {
-        trace!("register_fiat_topup() - called with - email: {email:?} - user_iban: {user_iban} - user_currency: {user_currency:?}");
+        debug!("register_fiat_topup() - called with - email: {email:?} - user_iban: {user_iban} - user_currency: {user_currency:?}");
         user_iban
             .parse::<Iban>()
             .map_to_invalid_input("Invalid user_iban")?;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -12,12 +12,12 @@ use std::sync::Once;
 fn init_logger(min_level: Level, path: &Path) {
     let base_log_file = path.join("logs.txt");
 
-    // Main log file ~10MB + 3 compressed older logs ~2MB = Total storage taken of ~12MB
-    // Compressing all log files leads to a ~3MB file and provides latest 200k logged lines
+    // Main log file ~25MB + 9 compressed older logs <2MB = Total storage < 50MB
+    // Logs provide latest 1M logged lines
     let rotated_log = FileRotate::new(
         base_log_file,
-        AppendCount::new(3),
-        ContentLimit::Lines(50_000),
+        AppendCount::new(7),
+        ContentLimit::Lines(100_000),
         Compression::OnRotate(0),
         None,
     );


### PR DESCRIPTION
Didn't find a way to filter different modules using different log levels with our current logger (from crate `simplelog`). To avoid the complexity of changing the implementation, I propose we increase the limits on log file size and log file amount as well as reduce the log level from `trace` to `debug`.

If we find a need, we can come back to this later.