### PR TITLE
Include paid LSP fee in requested amount

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ use perro::{
 use squirrel::RemoteBackupClient;
 use std::cmp::Reverse;
 use std::collections::HashSet;
-use std::ops::Not;
+use std::ops::{Add, Not};
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
@@ -955,6 +955,7 @@ impl LightningNode {
                         .to_amount_down(&exchange_rate),
                     breez_payment
                         .amount_msat
+                        .add(breez_payment.fee_msat)
                         .as_msats()
                         .to_amount_down(&exchange_rate),
                     None,


### PR DESCRIPTION
The `requested_amount` is described as: `/// Nominal amount specified in the invoice.`

AFAIU we should put the number that the sender sees in his invoice here, which is essentially `received_amount + paid_lsp_fee`.