### PR TITLE
Fix backwards compatibility for lightning payout fees

### DIFF
--- a/src/data_store.rs
+++ b/src/data_store.rs
@@ -404,7 +404,7 @@ fn offer_kind_from_row(row: &Row) -> rusqlite::Result<Option<OfferKind>> {
             let topup_value_minor_units: u64 = row.get(9)?;
             let exchange_fee_minor_units: u64 = row.get(10)?;
             let exchange_fee_rate_permyriad: u16 = row.get(11)?;
-            let topup_value_sats: u64 = row.get(13)?;
+            let topup_value_sats: Option<u64> = row.get(13)?;
 
             let exchange_rate = ExchangeRate {
                 currency_code: fiat_currency,
@@ -586,7 +586,7 @@ mod tests {
             id: "id".to_string(),
             exchange_rate: exchange_rate.clone(),
             topup_value_minor_units: 51245,
-            topup_value_sats: 2625281,
+            topup_value_sats: Some(2625281),
             exchange_fee_minor_units: 123,
             exchange_fee_rate_permyriad: 50,
             lightning_payout_fee: None,
@@ -604,7 +604,7 @@ mod tests {
             id: "id".to_string(),
             exchange_rate: exchange_rate.clone(),
             topup_value_minor_units: 51245,
-            topup_value_sats: 2625281,
+            topup_value_sats: Some(2625281),
             exchange_fee_minor_units: 123,
             exchange_fee_rate_permyriad: 50,
             lightning_payout_fee: None,
@@ -818,7 +818,7 @@ mod tests {
             id: "id".to_string(),
             exchange_rate: exchange_rate.clone(),
             topup_value_minor_units: 51245,
-            topup_value_sats: 2625281,
+            topup_value_sats: Some(2625281),
             exchange_fee_minor_units: 123,
             exchange_fee_rate_permyriad: 50,
             lightning_payout_fee: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1828,9 +1828,12 @@ fn fill_payout_fee(
             lightning_payout_fee: _,
             error,
         } => {
-            let lightning_payout_fee =
-                (topup_value_sats.as_sats().msats - requested_amount.msats).as_msats();
-            let lightning_payout_fee = Some(lightning_payout_fee.to_amount_up(rate));
+            let lightning_payout_fee = topup_value_sats.map(|v| {
+                (v.as_sats().msats - requested_amount.msats)
+                    .as_msats()
+                    .to_amount_up(rate)
+            });
+
             OfferKind::Pocket {
                 id,
                 exchange_rate,
@@ -2026,7 +2029,7 @@ mod tests {
                         updated_at: SystemTime::now(),
                     },
                     topup_value_minor_units: 0,
-                    topup_value_sats: 0,
+                    topup_value_sats: Some(0),
                     exchange_fee_minor_units: 0,
                     exchange_fee_rate_permyriad: 0,
                     lightning_payout_fee: None,
@@ -2075,7 +2078,7 @@ mod tests {
                         updated_at: SystemTime::now(),
                     },
                     topup_value_minor_units: 0,
-                    topup_value_sats: 0,
+                    topup_value_sats: Some(0),
                     exchange_fee_minor_units: 0,
                     exchange_fee_rate_permyriad: 0,
                     lightning_payout_fee: None,

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -374,7 +374,7 @@ interface OfferKind {
         string id,
         ExchangeRate exchange_rate,
         u64 topup_value_minor_units,
-        u64 topup_value_sats,
+        u64? topup_value_sats,
         u64 exchange_fee_minor_units,
         u16 exchange_fee_rate_permyriad,
         Amount? lightning_payout_fee,

--- a/src/offer.rs
+++ b/src/offer.rs
@@ -29,8 +29,8 @@ pub enum OfferKind {
         exchange_rate: ExchangeRate,
         /// The original fiat amount sent to the exchange.
         topup_value_minor_units: u64,
-        /// The sat amount after the exchange.
-        topup_value_sats: u64,
+        /// The sat amount after the exchange. Isn't available for topups collected before version v0.30.0-beta.
+        topup_value_sats: Option<u64>,
         /// The fee paid to perform the exchange from fiat to sats.
         exchange_fee_minor_units: u64,
         /// The rate of the fee expressed in permyriad (e.g. 1.5% would be 150).
@@ -79,7 +79,7 @@ impl OfferInfo {
                 id: topup_info.id,
                 exchange_rate,
                 topup_value_minor_units: topup_info.topup_value_minor_units,
-                topup_value_sats: topup_info.amount_sat,
+                topup_value_sats: Some(topup_info.amount_sat),
                 exchange_fee_minor_units: topup_info.exchange_fee_minor_units,
                 exchange_fee_rate_permyriad: topup_info.exchange_fee_rate_permyriad,
                 lightning_payout_fee: None,


### PR DESCRIPTION
Fixes backwards compatibility issues for offers collected/created before v0.30.0-beta.