### PR TITLE
Rename `Activity` variants

### DIFF
--- a/examples/node/cli.rs
+++ b/examples/node/cli.rs
@@ -1011,8 +1011,8 @@ fn list_activities(node: &LightningNode, words: &mut dyn Iterator<Item = &str>) 
 
 fn print_activity(activity: Activity) -> Result<()> {
     match activity {
-        Activity::Payment { payment } => print_payment(payment),
-        Activity::ChannelClose { channel_close } => print_channel_close(channel_close),
+        Activity::PaymentActivity { payment } => print_payment(payment),
+        Activity::ChannelCloseActivity { channel_close } => print_channel_close(channel_close),
     }
 }
 

--- a/examples/node/overview.rs
+++ b/examples/node/overview.rs
@@ -85,8 +85,8 @@ pub fn overview(node: &LightningNode, words: &mut dyn Iterator<Item = &str>) -> 
 
 fn print_activity(activity: Activity) -> Result<()> {
     match activity {
-        Activity::Payment { payment } => print_payment(payment),
-        Activity::ChannelClose { channel_close } => print_channel_close(channel_close),
+        Activity::PaymentActivity { payment } => print_payment(payment),
+        Activity::ChannelCloseActivity { channel_close } => print_channel_close(channel_close),
     }
 }
 

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -79,15 +79,15 @@ pub struct ListActivitiesResponse {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, PartialEq)]
 pub enum Activity {
-    Payment { payment: Payment },
-    ChannelClose { channel_close: ChannelClose },
+    PaymentActivity { payment: Payment },
+    ChannelCloseActivity { channel_close: ChannelClose },
 }
 
 impl Activity {
     pub(crate) fn get_time(&self) -> SystemTime {
         match self {
-            Activity::Payment { payment } => payment.created_at.time,
-            Activity::ChannelClose { channel_close } => channel_close
+            Activity::PaymentActivity { payment } => payment.created_at.time,
+            Activity::ChannelCloseActivity { channel_close } => channel_close
                 .closed_at
                 .clone()
                 .map(|t| t.time)
@@ -97,11 +97,11 @@ impl Activity {
 
     pub(crate) fn is_pending(&self) -> bool {
         match self {
-            Activity::Payment { payment } => matches!(
+            Activity::PaymentActivity { payment } => matches!(
                 payment.payment_state,
                 PaymentState::Created | PaymentState::Retried
             ),
-            Activity::ChannelClose { channel_close } => match channel_close.state {
+            Activity::ChannelCloseActivity { channel_close } => match channel_close.state {
                 ChannelCloseState::Pending => true,
                 ChannelCloseState::Confirmed => false,
             },

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -282,8 +282,8 @@ interface MaxRoutingFeeMode {
 
 [Enum]
 interface Activity {
-    Payment(Payment payment);
-    ChannelClose(ChannelClose channel_close);
+    PaymentActivity(Payment payment);
+    ChannelCloseActivity(ChannelClose channel_close);
 };
 
 dictionary ListActivitiesResponse {

--- a/tests/payment_fetching_test.rs
+++ b/tests/payment_fetching_test.rs
@@ -27,7 +27,7 @@ fn test_payment_fetching() {
 
     let latest_activities = node.get_latest_activities(1).unwrap();
     let activity_from_list = latest_activities.pending_activities.first().unwrap();
-    assert_eq!(&Activity::Payment { payment }, activity_from_list);
+    assert_eq!(&Activity::PaymentActivity { payment }, activity_from_list);
 }
 
 fn assert_invoice_matches_payment(invoice: &InvoiceDetails, payment: &Payment) {


### PR DESCRIPTION
This is necessary to circumvent an issue with the Kotlin bindings. The enum variant having the same name as the type of the associated variant type causes an error.