### PR TITLE
Expose recipient field

### DIFF
--- a/examples/node/cli.rs
+++ b/examples/node/cli.rs
@@ -1058,7 +1058,7 @@ fn print_payment(payment: Payment) -> Result<()> {
     );
     println!("      Offer:            {}", offer_to_string(payment.offer));
     println!("      Swap:             {:?}", payment.swap);
-    println!("     Lightning Address: {:?}", payment.lightning_address);
+    println!("      Recipient:        {:?}", payment.recipient);
     Ok(())
 }
 

--- a/examples/node/overview.rs
+++ b/examples/node/overview.rs
@@ -5,7 +5,7 @@ use colored::Colorize;
 use thousands::Separable;
 use uniffi_lipalightninglib::{
     Activity, Amount, BreezHealthCheckStatus, ChannelClose, FiatValue, LightningNode, Payment,
-    PaymentState, PaymentType,
+    PaymentState, PaymentType, Recipient,
 };
 
 pub fn overview(node: &LightningNode, words: &mut dyn Iterator<Item = &str>) -> Result<()> {
@@ -121,9 +121,9 @@ fn print_payment(payment: Payment) -> Result<()> {
         println!("{lsp_fees}");
     }
 
-    let (icon, title) = match payment.lightning_address {
-        Some(lightning_address) => (" @".bold(), lightning_address),
-        None => ("🧾".normal(), "Invoice".to_string()),
+    let (icon, title) = match payment.recipient {
+        Some(Recipient::LightningAddress { address }) => (" @".bold(), address),
+        Some(Recipient::Unknown) | None => ("🧾".normal(), "Invoice".to_string()),
     };
 
     let amount = payment.requested_amount.sats.separate_with_commas();

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -66,8 +66,15 @@ pub struct Payment {
     pub offer: Option<OfferKind>,
     /// The swap information of a [`PaymentType::Receiving`] payment if triggered by a swap.
     pub swap: Option<SwapInfo>,
-    /// A lightning address the payment has been sent to.
-    pub lightning_address: Option<String>,
+    /// Information about a payment's recipient. Will only be present for outgoing payments.
+    pub recipient: Option<Recipient>,
+}
+
+/// User-friendly representation of an outgoing payment's recipient.
+#[derive(PartialEq, Debug)]
+pub enum Recipient {
+    LightningAddress { address: String },
+    Unknown,
 }
 
 /// Information about **all** pending and **only** requested completed activities.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ use crate::task_manager::TaskManager;
 use crate::util::LogIgnoreError;
 use crate::util::{replace_byte_arrays_by_hex_string, unix_timestamp_to_system_time};
 
+pub use crate::activity::Recipient;
 use crate::swap::SwapToLightningFees;
 pub use breez_sdk_core::error::ReceiveOnchainError as SwapError;
 use breez_sdk_core::error::{LnUrlWithdrawError, ReceiveOnchainError, SendPaymentError};
@@ -1131,6 +1132,14 @@ impl LightningNode {
             paid_sats: s.paid_sats,
         });
 
+        let recipient = match &payment_details.ln_address {
+            None => match breez_payment.payment_type {
+                breez_sdk_core::PaymentType::Sent => Some(Recipient::Unknown),
+                _ => None,
+            },
+            Some(a) => Some(Recipient::LightningAddress { address: a.clone() }),
+        };
+
         Ok(Activity::PaymentActivity {
             payment: Payment {
                 payment_type,
@@ -1151,7 +1160,7 @@ impl LightningNode {
                 lsp_fees,
                 offer,
                 swap,
-                lightning_address: payment_details.ln_address.clone(),
+                recipient,
             },
         })
     }
@@ -1270,7 +1279,7 @@ impl LightningNode {
             lsp_fees,
             offer: None,
             swap: None,
-            lightning_address: None,
+            recipient: None,
         })
     }
 
@@ -2405,7 +2414,7 @@ mod tests {
                 lsp_fees: None,
                 offer: None,
                 swap: None,
-                lightning_address: None,
+                recipient: None,
             },
             Payment {
                 payment_type: PaymentType::Receiving,
@@ -2454,7 +2463,7 @@ mod tests {
                     error: None,
                 }),
                 swap: None,
-                lightning_address: None,
+                recipient: None,
             },
             Payment {
                 payment_type: PaymentType::Receiving,
@@ -2503,7 +2512,7 @@ mod tests {
                     error: None,
                 }),
                 swap: None,
-                lightning_address: None,
+                recipient: None,
             },
         ];
 

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -318,7 +318,7 @@ dictionary Payment {
     Amount? lsp_fees;
     OfferKind? offer;
     SwapInfo? swap;
-    string? lightning_address;
+    Recipient? recipient;
 };
 
 enum PaymentType {
@@ -531,6 +531,13 @@ dictionary SwapToLightningFees {
     Amount total_fees;
     OpeningFeeParams? lsp_fee_params;
 };
+
+[Enum]
+interface Recipient {
+    LightningAddress(string address);
+    Unknown();
+};
+
 
 //
 // ----------------------------- TOP LEVEL FUNCTIONS + RELATED DEFINITIONS -----------------------------


### PR DESCRIPTION
The idea is for us to start adding more recipient variants as we go. Examples: custodial provider, non-custodial nodeid-based alias, onchain address.