### PR TITLE
Expose short and long descriptions of LNURL-pay

### DIFF
--- a/examples/node/cli.rs
+++ b/examples/node/cli.rs
@@ -620,6 +620,14 @@ fn print_lnurl_pay_details(lnurl_pay_details: LnUrlPayDetails) {
     println!("LNURL-pay details:");
     println!("  Domain                {}", lnurl_pay_details.domain);
     println!(
+        "  Short Description     {}",
+        lnurl_pay_details.short_description
+    );
+    println!(
+        "  Long Description      {:?}",
+        lnurl_pay_details.long_description
+    );
+    println!(
         "  Min Sendable          {}",
         amount_to_string(lnurl_pay_details.min_sendable)
     );
@@ -627,14 +635,14 @@ fn print_lnurl_pay_details(lnurl_pay_details: LnUrlPayDetails) {
         "  Max Sendable          {}",
         amount_to_string(lnurl_pay_details.max_sendable)
     );
-    println!("---- Internal request_data struct ----");
+    println!("---- Internal LnUrlPayRequestData struct ----");
     println!(
         "  Callback              {}",
         lnurl_pay_details.request_data.callback
     );
     let len = min(lnurl_pay_details.request_data.metadata_str.len(), 50);
     println!(
-        "  Metadata              {}...",
+        "  Metadata              {}…",
         lnurl_pay_details
             .request_data
             .metadata_str
@@ -646,11 +654,7 @@ fn print_lnurl_pay_details(lnurl_pay_details: LnUrlPayDetails) {
         lnurl_pay_details.request_data.comment_allowed
     );
     println!(
-        "  Domain                {}",
-        lnurl_pay_details.request_data.domain
-    );
-    println!(
-        "  LN Address            {:?}",
+        "  Lightning Address     {:?}",
         lnurl_pay_details.request_data.ln_address
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -622,7 +622,7 @@ impl LightningNode {
                 lnurl_pay_details: LnUrlPayDetails::from_lnurl_pay_request_data(
                     data,
                     &self.get_exchange_rate(),
-                ),
+                )?,
             }),
             Ok(InputType::BitcoinAddress { .. }) => Err(DecodeDataError::Unsupported {
                 typ: UnsupportedDataType::BitcoinAddress,

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -231,6 +231,8 @@ interface DecodedData {
 
 dictionary LnUrlPayDetails {
     string domain;
+    string short_description;
+    string? long_description;
     Amount min_sendable;
     Amount max_sendable;
     LnUrlPayRequestData request_data;

--- a/src/lnurl.rs
+++ b/src/lnurl.rs
@@ -1,12 +1,16 @@
 use crate::amount::{AsSats, ToAmount};
+use crate::errors::DecodeDataError;
 use crate::{Amount, ExchangeRate};
-use breez_sdk_core::{LnUrlPayRequestData, LnUrlWithdrawRequestData};
+use breez_sdk_core::{LnUrlPayRequestData, LnUrlWithdrawRequestData, MetadataItem};
+use perro::ensure;
 
 /// Information about an LNURL-pay.
 pub struct LnUrlPayDetails {
     /// The domain of the LNURL-pay service, to be shown to the user when asking for
     /// payment input, as per LUD-06 spec.
     pub domain: String,
+    pub short_description: String,
+    pub long_description: Option<String>,
     pub min_sendable: Amount,
     pub max_sendable: Amount,
     /// An internal struct is not supposed to be inspected, but only passed to [`crate::LightningNode::pay_lnurlp`].
@@ -17,9 +21,29 @@ impl LnUrlPayDetails {
     pub(crate) fn from_lnurl_pay_request_data(
         request_data: LnUrlPayRequestData,
         exchange_rate: &Option<ExchangeRate>,
-    ) -> Self {
-        Self {
+    ) -> std::result::Result<Self, DecodeDataError> {
+        let mut short_description = String::new();
+        let mut long_description = None;
+        let metadata = request_data
+            .metadata_vec()
+            .map_err(|e| DecodeDataError::LnUrlError { msg: e.to_string() })?;
+        for MetadataItem { key, value } in metadata {
+            match key.as_str() {
+                "text/plain" => short_description = value.clone(),
+                "text/long-desc" => long_description = Some(value.clone()),
+                _ => (),
+            }
+        }
+        ensure!(
+            !short_description.is_empty(),
+            DecodeDataError::LnUrlError {
+                msg: "Missing short description".to_string()
+            }
+        );
+        Ok(Self {
             domain: request_data.domain.clone(),
+            short_description,
+            long_description,
             min_sendable: request_data
                 .min_sendable
                 .as_msats()
@@ -29,7 +53,7 @@ impl LnUrlPayDetails {
                 .as_msats()
                 .to_amount_up(exchange_rate),
             request_data,
-        }
+        })
     }
 }
 


### PR DESCRIPTION
As per LUD-06:

> Additionally, a payment dialog must include:
>     Domain name extracted from LNURL query string.
>     A way to view the metadata sent of `text/plain` format.

```
3L ϟ decodedata lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNXD9SHG6NPVCHXXMMD9AKXUATJDSKHQCTE8AEK2UMND9HKU0FSVFJRWVEHXUCXYCEC8YUNYCMR8PJKVE3K8QCXYE3KXUMNYDRZ893XYC3KVSCRJETRV93R2EPSV5MR2CNX8Y6NQDMR8Q6NXDMPV3JR2QF5HCH
LNURL-pay details:
  Domain                lnurl.fiatjaf.com
  Short Description     YPUTuGdcMLCp
  Long Description      Some("XTlAYDfeOdZqqUfFvFeoZ MO")
  Min Sendable          9 SAT (0.01 EUR as of 22/01/2024 11:35:01 UTC)
  Max Sendable          9 SAT (0.01 EUR as of 22/01/2024 11:35:01 UTC)
---- Internal LnUrlPayRequestData struct ----
  Callback              https://lnurl.fiatjaf.com/lnurl-pay/callback/0bd73770bc8992cc8eff680bf67724b9bbb6d09ecab5d0e65bf9507c8537add5
  Metadata              [["text/plain","YPUTuGdcMLCp"],["text/long-desc","…
  Comment Allowed       0
  Lightning Address     None
```