### PR TITLE
Remove new lines from get branch name

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -355,7 +355,7 @@ jobs:
       - name: Get Branch Name
         id: get-branch
         run: |
-          BRANCH_NAMES=$(git branch -r --contains ${GITHUB_REF_NAME} | grep origin | sed 's/origin\///' | sed 's/ //g')
+          BRANCH_NAMES=$(git branch -r --contains ${GITHUB_REF_NAME} | grep origin | sed 's/origin\///' | sed 's/ //g' | sed ':a;N;$!ba;s/\n//g')
           echo "BRANCH_NAMES=$BRANCH_NAMES" >> "$GITHUB_ENV"
           echo "Branch names: $BRANCH_NAMES"
       - name: Set Output Variable


### PR DESCRIPTION
Fix the issue where a multiline variable was trying to be set in github's env.