### PR TITLE
Release mock artifacts

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -211,6 +211,7 @@ jobs:
           git add Package.swift
           git add Sources/LipaLightningLib/LipaLightningLib.swift
           git commit -m "This commit was created automatically by the lipa bot"
+          git pull --rebase
           git tag -a ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || ''}} HEAD -m "This tag was created automatically by the lipa bot."
           git push
           git push --tag
@@ -314,6 +315,7 @@ jobs:
           git add LipaLightningLib/src/main/java/com/getlipa/lipalightninglib/lipalightninglib.kt
           git add jitpack.yml
           git commit -m "This commit was created automatically by the lipa bot"
+          git pull --rebase
           git tag -a ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || ''}} HEAD -m "This tag was created automatically by the lipa bot."
           git push
           git push --tag

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -348,7 +348,7 @@ jobs:
             --prerelease
       - name: Trigger JitPack build
         run: |
-          curl -s -m 30 https://jitpack.io/com/github/getlipa/lipa-lightning-lib-android/${{ env.RELEASE_VERSION }} || true
+          curl -s -m 30 https://jitpack.io/com/github/getlipa/lipa-lightning-lib-android/${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }} || true
 
   determine-branch:
     name: determine-branch

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -19,6 +19,7 @@ jobs:
     strategy:
       matrix:
         target: [ x86_64-apple-ios, aarch64-apple-ios, aarch64-apple-ios-sim ]
+        mock-deps: [ false, true ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -44,18 +45,18 @@ jobs:
         with:
           use-cross: false
           command: build
-          args: --release --target ${{ matrix.target }}
+          args: ${{ matrix.mock-deps && '--no-default-features --features mock-deps' || '' }} --release --target ${{ matrix.target }}
       - name: Upload library binaries
         uses: actions/upload-artifact@v4
         with:
           path: target/${{ matrix.target }}/release/libuniffi_lipalightninglib.a
-          name: build-${{ matrix.target }}
+          name: build-${{ matrix.target }}${{ matrix.mock-deps && '-mock' || ''}}
       - name: Upload bindings files
         uses: actions/upload-artifact@v4
         if: ${{ matrix.target == 'x86_64-apple-ios' }}
         with:
           path: bindings/swift/lipalightninglib*
-          name: bindings-files-ios
+          name: bindings-files-ios${{ matrix.mock-deps && '-mock' || ''}}
 
   cross-compile-android:
     name: cross-compile-android
@@ -63,6 +64,7 @@ jobs:
     strategy:
       matrix:
         target: [ aarch64-linux-android, armv7-linux-androideabi, i686-linux-android ]
+        mock-deps: [ false, true ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -90,39 +92,42 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --release --target ${{ matrix.target }}
+          args: ${{ matrix.mock-deps && '--no-default-features --features mock-deps' || '' }} --release --target ${{ matrix.target }}
       - name: Upload library binaries
         uses: actions/upload-artifact@v4
         with:
           path: target/${{ matrix.target }}/release/libuniffi_lipalightninglib.so
-          name: build-${{ matrix.target }}
+          name: build-${{ matrix.target }}${{ matrix.mock-deps && '-mock' || ''}}
       - name: Upload bindings file
         uses: actions/upload-artifact@v4
         if: ${{ matrix.target == 'aarch64-linux-android' }}
         with:
           path: bindings/kotlin/uniffi/lipalightninglib/lipalightninglib.kt
-          name: bindings-file-android
+          name: bindings-file-android${{ matrix.mock-deps && '-mock' || ''}}
 
   lipo-ios:
     name: lipo-ios
     needs: [ cross-compile-ios, cross-compile-android ]
     runs-on: macos-latest
+    strategy:
+      matrix:
+        mock-deps: [ false, true ]
     steps:
       - name: Download x86 bin
         uses: actions/download-artifact@v4
         with:
           path: target/x86_64-apple-ios/release
-          name: build-x86_64-apple-ios
+          name: build-x86_64-apple-ios${{ matrix.mock-deps && '-mock' || ''}}
       - name: Download aarch64 bin
         uses: actions/download-artifact@v4
         with:
           path: target/aarch64-apple-ios/release
-          name: build-aarch64-apple-ios
+          name: build-aarch64-apple-ios${{ matrix.mock-deps && '-mock' || ''}}
       - name: Download aarch64sim bin
         uses: actions/download-artifact@v4
         with:
           path: target/aarch64-apple-ios-sim/release
-          name: build-aarch64-apple-ios-sim
+          name: build-aarch64-apple-ios-sim${{ matrix.mock-deps && '-mock' || ''}}
       - name: Package simulator binaries
         run: |
           mkdir -p target/universal/release
@@ -133,12 +138,15 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: target/universal/release/libuniffi_lipalightninglib_simulator.a
-          name: build-ios-simulator-universal
+          name: build-ios-simulator-universal${{ matrix.mock-deps && '-mock' || ''}}
 
   deploy-ios:
     name: deploy-ios
     needs: lipo-ios
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mock-deps: [ false, true ]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -165,17 +173,17 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: target/aarch64-apple-ios/release
-          name: build-aarch64-apple-ios
+          name: build-aarch64-apple-ios${{ matrix.mock-deps && '-mock' || ''}}
       - name: Download simulator universal bin
         uses: actions/download-artifact@v4
         with:
           path: target/universal/release
-          name: build-ios-simulator-universal
+          name: build-ios-simulator-universal${{ matrix.mock-deps && '-mock' || ''}}
       - name: Download bindings files
         uses: actions/download-artifact@v4
         with:
           path: bindings/swift/
-          name: bindings-files-ios
+          name: bindings-files-ios${{ matrix.mock-deps && '-mock' || ''}}
       - name: Create xcframework
         run: |
           git clone git@github.com:getlipa/lipa-lightning-lib-swift.git
@@ -208,7 +216,7 @@ jobs:
           git add Package.swift
           git add Sources/LipaLightningLib/LipaLightningLib.swift
           git commit -m "This commit was created automatically by the lipa bot"
-          git tag -a ${{ env.RELEASE_VERSION }} HEAD -m "This tag was created automatically by the lipa bot."
+          git tag -a ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || ''}} HEAD -m "This tag was created automatically by the lipa bot."
           git push
           git push --tag
       - name: Create release
@@ -263,22 +271,22 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: target/aarch64-linux-android/release
-          name: build-aarch64-linux-android
+          name: build-aarch64-linux-android${{ matrix.mock-deps && '-mock' || ''}}
       - name: Download armv7 bin
         uses: actions/download-artifact@v4
         with:
           path: target/armv7-linux-androideabi/release
-          name: build-armv7-linux-androideabi
+          name: build-armv7-linux-androideabi${{ matrix.mock-deps && '-mock' || ''}}
       - name: Download i686 bin
         uses: actions/download-artifact@v4
         with:
           path: target/i686-linux-android/release
-          name: build-i686-linux-android
+          name: build-i686-linux-android${{ matrix.mock-deps && '-mock' || ''}}
       - name: Download bindings file
         uses: actions/download-artifact@v4
         with:
           path: bindings/kotlin/uniffi/lipalightninglib
-          name: bindings-file-android
+          name: bindings-file-android${{ matrix.mock-deps && '-mock' || ''}}
       - name: Push to target repo
         run: |
           git clone git@github.com:getlipa/lipa-lightning-lib-android.git
@@ -311,7 +319,7 @@ jobs:
           git add LipaLightningLib/src/main/java/com/getlipa/lipalightninglib/lipalightninglib.kt
           git add jitpack.yml
           git commit -m "This commit was created automatically by the lipa bot"
-          git tag -a ${{ env.RELEASE_VERSION }} HEAD -m "This tag was created automatically by the lipa bot."
+          git tag -a ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || ''}} HEAD -m "This tag was created automatically by the lipa bot."
           git push
           git push --tag
       - name: Create release

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -147,6 +147,7 @@ jobs:
     strategy:
       matrix:
         mock-deps: [ false, true ]
+      max-parallel: 1
     steps:
       - uses: actions/checkout@v2
         with:
@@ -211,7 +212,6 @@ jobs:
           git add Package.swift
           git add Sources/LipaLightningLib/LipaLightningLib.swift
           git commit -m "This commit was created automatically by the lipa bot"
-          git status
           git restore .
           git pull --rebase
           git tag -a ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || ''}} HEAD -m "This tag was created automatically by the lipa bot."

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -193,11 +193,6 @@ jobs:
           cp target/universal/release/libuniffi_lipalightninglib_simulator.a lipa-lightning-lib-swift/lipalightninglibFFI.xcframework/ios-arm64_x86_64-simulator/lipalightninglibFFI.framework/lipalightninglibFFI
           cd lipa-lightning-lib-swift
           zip -9 -r lipalightninglibFFI.xcframework.zip lipalightninglibFFI.xcframework
-      - name: Upload xcframework zip
-        uses: actions/upload-artifact@v4
-        with:
-          path: lipa-lightning-lib-swift/lipalightninglibFFI.xcframework.zip
-          name: lipalightninglibFFI.xcframework
       - name: Push to target repo
         env:
           GITHUB_TOKEN: ${{ secrets.LIPA_BOT_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -211,6 +211,8 @@ jobs:
           git add Package.swift
           git add Sources/LipaLightningLib/LipaLightningLib.swift
           git commit -m "This commit was created automatically by the lipa bot"
+          git status
+          git restore .
           git pull --rebase
           git tag -a ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || ''}} HEAD -m "This tag was created automatically by the lipa bot."
           git push

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -50,13 +50,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: target/${{ matrix.target }}/release/libuniffi_lipalightninglib.a
-          name: build-${{ matrix.target }}${{ matrix.mock-deps && '-mock' || ''}}
+          name: build-${{ matrix.target }}${{ matrix.mock-deps && '-mock' || '' }}
       - name: Upload bindings files
         uses: actions/upload-artifact@v4
         if: ${{ matrix.target == 'x86_64-apple-ios' }}
         with:
           path: bindings/swift/lipalightninglib*
-          name: bindings-files-ios${{ matrix.mock-deps && '-mock' || ''}}
+          name: bindings-files-ios${{ matrix.mock-deps && '-mock' || '' }}
 
   cross-compile-android:
     name: cross-compile-android
@@ -97,13 +97,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: target/${{ matrix.target }}/release/libuniffi_lipalightninglib.so
-          name: build-${{ matrix.target }}${{ matrix.mock-deps && '-mock' || ''}}
+          name: build-${{ matrix.target }}${{ matrix.mock-deps && '-mock' || '' }}
       - name: Upload bindings file
         uses: actions/upload-artifact@v4
         if: ${{ matrix.target == 'aarch64-linux-android' }}
         with:
           path: bindings/kotlin/uniffi/lipalightninglib/lipalightninglib.kt
-          name: bindings-file-android${{ matrix.mock-deps && '-mock' || ''}}
+          name: bindings-file-android${{ matrix.mock-deps && '-mock' || '' }}
 
   lipo-ios:
     name: lipo-ios
@@ -117,17 +117,17 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: target/x86_64-apple-ios/release
-          name: build-x86_64-apple-ios${{ matrix.mock-deps && '-mock' || ''}}
+          name: build-x86_64-apple-ios${{ matrix.mock-deps && '-mock' || '' }}
       - name: Download aarch64 bin
         uses: actions/download-artifact@v4
         with:
           path: target/aarch64-apple-ios/release
-          name: build-aarch64-apple-ios${{ matrix.mock-deps && '-mock' || ''}}
+          name: build-aarch64-apple-ios${{ matrix.mock-deps && '-mock' || '' }}
       - name: Download aarch64sim bin
         uses: actions/download-artifact@v4
         with:
           path: target/aarch64-apple-ios-sim/release
-          name: build-aarch64-apple-ios-sim${{ matrix.mock-deps && '-mock' || ''}}
+          name: build-aarch64-apple-ios-sim${{ matrix.mock-deps && '-mock' || '' }}
       - name: Package simulator binaries
         run: |
           mkdir -p target/universal/release
@@ -138,7 +138,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: target/universal/release/libuniffi_lipalightninglib_simulator.a
-          name: build-ios-simulator-universal${{ matrix.mock-deps && '-mock' || ''}}
+          name: build-ios-simulator-universal${{ matrix.mock-deps && '-mock' || '' }}
 
   deploy-ios:
     name: deploy-ios
@@ -174,17 +174,17 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: target/aarch64-apple-ios/release
-          name: build-aarch64-apple-ios${{ matrix.mock-deps && '-mock' || ''}}
+          name: build-aarch64-apple-ios${{ matrix.mock-deps && '-mock' || '' }}
       - name: Download simulator universal bin
         uses: actions/download-artifact@v4
         with:
           path: target/universal/release
-          name: build-ios-simulator-universal${{ matrix.mock-deps && '-mock' || ''}}
+          name: build-ios-simulator-universal${{ matrix.mock-deps && '-mock' || '' }}
       - name: Download bindings files
         uses: actions/download-artifact@v4
         with:
           path: bindings/swift/
-          name: bindings-files-ios${{ matrix.mock-deps && '-mock' || ''}}
+          name: bindings-files-ios${{ matrix.mock-deps && '-mock' || '' }}
       - name: Create xcframework
         run: |
           git clone git@github.com:getlipa/lipa-lightning-lib-swift.git
@@ -214,7 +214,7 @@ jobs:
           git commit -m "This commit was created automatically by the lipa bot"
           git restore .
           git pull --rebase
-          git tag -a ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || ''}} HEAD -m "This tag was created automatically by the lipa bot."
+          git tag -a ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }} HEAD -m "This tag was created automatically by the lipa bot."
           git push
           git push --tag
       - name: Create release
@@ -233,9 +233,9 @@ jobs:
         if: ${{ env.BRANCH != 'main' }}
         run: |
           cd lipa-lightning-lib-swift
-          gh release create ${{ env.RELEASE_VERSION }} \
+          gh release create ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }} \
             lipalightninglibFFI.xcframework.zip \
-            --title "${{ env.RELEASE_VERSION }}" \
+            --title "${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }}" \
             --notes "This pre-release was created automatically by the lipa bot. For more information, please access the corresponding release in https://github.com/getlipa/lipa-lightning-lib" \
             --prerelease
 
@@ -273,22 +273,22 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: target/aarch64-linux-android/release
-          name: build-aarch64-linux-android${{ matrix.mock-deps && '-mock' || ''}}
+          name: build-aarch64-linux-android${{ matrix.mock-deps && '-mock' || '' }}
       - name: Download armv7 bin
         uses: actions/download-artifact@v4
         with:
           path: target/armv7-linux-androideabi/release
-          name: build-armv7-linux-androideabi${{ matrix.mock-deps && '-mock' || ''}}
+          name: build-armv7-linux-androideabi${{ matrix.mock-deps && '-mock' || '' }}
       - name: Download i686 bin
         uses: actions/download-artifact@v4
         with:
           path: target/i686-linux-android/release
-          name: build-i686-linux-android${{ matrix.mock-deps && '-mock' || ''}}
+          name: build-i686-linux-android${{ matrix.mock-deps && '-mock' || '' }}
       - name: Download bindings file
         uses: actions/download-artifact@v4
         with:
           path: bindings/kotlin/uniffi/lipalightninglib
-          name: bindings-file-android${{ matrix.mock-deps && '-mock' || ''}}
+          name: bindings-file-android${{ matrix.mock-deps && '-mock' || '' }}
       - name: Push to target repo
         run: |
           git clone git@github.com:getlipa/lipa-lightning-lib-android.git
@@ -322,7 +322,7 @@ jobs:
           git add jitpack.yml
           git commit -m "This commit was created automatically by the lipa bot"
           git pull --rebase
-          git tag -a ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || ''}} HEAD -m "This tag was created automatically by the lipa bot."
+          git tag -a ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }} HEAD -m "This tag was created automatically by the lipa bot."
           git push
           git push --tag
       - name: Create release
@@ -331,9 +331,9 @@ jobs:
         if: ${{ env.BRANCH == 'main' }}
         run: |
           cd lipa-lightning-lib-android
-          gh release create ${{ env.RELEASE_VERSION }} \
+          gh release create ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }} \
             jniLibs.zip \
-            --title "${{ env.RELEASE_VERSION }}" \
+            --title "${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }}" \
             --notes "This release was created automatically by the lipa bot. For more information, please access the corresponding release in https://github.com/getlipa/lipa-lightning-lib"
       - name: Create pre-release
         env:
@@ -341,9 +341,9 @@ jobs:
         if: ${{ env.BRANCH != 'main' }}
         run: |
           cd lipa-lightning-lib-android
-          gh release create ${{ env.RELEASE_VERSION }} \
+          gh release create ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }} \
             jniLibs.zip \
-            --title "${{ env.RELEASE_VERSION }}" \
+            --title "${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }}" \
             --notes "This pre-release was created automatically by the lipa bot. For more information, please access the corresponding release in https://github.com/getlipa/lipa-lightning-lib" \
             --prerelease
       - name: Trigger JitPack build

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -243,6 +243,10 @@ jobs:
     name: deploy-android
     needs: lipo-ios
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mock-deps: [ false, true ]
+      max-parallel: 1
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -206,7 +206,7 @@ jobs:
           
           cp Package.swift.template Package.swift
           shasum -a 256 lipalightninglibFFI.xcframework.zip | sed 's/ .*//' > checksum
-          sed -i "s/to_replace_release_version/${{ env.RELEASE_VERSION }}/g" Package.swift
+          sed -i "s/to_replace_release_version/${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }}/g" Package.swift
           sed -i "s/to_replace_zip_checksum/$(cat checksum)/g" Package.swift
           
           git add Package.swift
@@ -315,7 +315,7 @@ jobs:
           shasum -a 256 jniLibs.zip | sed 's/ .*//' > checksum
 
           cp jitpack.yml.template jitpack.yml
-          sed -i "s/to_replace_release_version/${{ env.RELEASE_VERSION }}/g" jitpack.yml
+          sed -i "s/to_replace_release_version/${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }}/g" jitpack.yml
           sed -i "s/to_replace_zip_checksum/$(cat checksum)/g" jitpack.yml
 
           git add LipaLightningLib/src/main/java/com/getlipa/lipalightninglib/lipalightninglib.kt


### PR DESCRIPTION
Whenever there is a new version tag like `v0.38.0-beta`, additional to the regular artifacts, with this PR also a mock artifact is built and deployed to [lipa-lightning-lib-android](https://github.com/getlipa/lipa-lightning-lib-android) resp. [lipa-lightning-lib-swift](https://github.com/getlipa/lipa-lightning-lib-swift) under a new tag, which would in the given case be `v0.38.0-beta-mock`.