### PR TITLE
Implement `handle_notification`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,3 +84,8 @@ run-node-mocked:
 .PHONY: run-parser-demo
 run-parser-demo:
 	cargo run --package parser --example demo
+
+.PHONY: run-notification-handler
+run-notification-handler: ARGS =
+run-notification-handler:
+	cargo run --example notification_handler -- $(ARGS)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ make run-node ARGS=dev
 ```
 `local` (default), `dev`, `stage`, and `prod` environments are available.
 
+To test background receive:
+ - start the regular example node, issue an invoice, and shut it down
+ - run `make run-notification-handler ARGS=<payment hash of issued invoice>`
+ - do either
+   - don't pay the invoice or pay a different invoice → after the timeout of 60 secs, the action `None` should be printed
+   - pay the invoice issued in step 1 → the action `ShowNotification` should be printed
+
 #### Logs
 View logs in `.3l_node_{ENVIRONMENT_CODE}/logs.txt`.
 

--- a/examples/notification_handler/main.rs
+++ b/examples/notification_handler/main.rs
@@ -6,14 +6,8 @@ use uniffi_lipalightninglib::{
 static BASE_DIR: &str = ".3l_node";
 
 fn main() {
-    let environment = env::args().nth(1).unwrap_or("local".to_string());
-    let hash = match env::args().nth(2) {
-        None => {
-            println!("A payment hash must be provided");
-            return;
-        }
-        Some(h) => h,
-    };
+    let hash = env::args().nth(1).expect("A payment hash must be provided");
+    let environment = env::args().nth(2).unwrap_or("local".to_string());
 
     println!("Starting a handle_notification test run.");
     println!("Environment: {environment}");

--- a/examples/notification_handler/main.rs
+++ b/examples/notification_handler/main.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::time::Duration;
 use uniffi_lipalightninglib::{
     handle_notification, mnemonic_to_secret, Config, EnvironmentCode, TzConfig,
 };
@@ -48,8 +47,7 @@ fn main() {
         }}"
     );
 
-    let action =
-        handle_notification(config, notification_payload, Duration::from_secs(60)).unwrap();
+    let action = handle_notification(config, notification_payload).unwrap();
 
     println!("The recommended action is {action:?}");
 }

--- a/examples/notification_handler/main.rs
+++ b/examples/notification_handler/main.rs
@@ -1,0 +1,71 @@
+use std::env;
+use std::time::Duration;
+use uniffi_lipalightninglib::{
+    handle_notification, mnemonic_to_secret, Config, EnvironmentCode, TzConfig,
+};
+
+static BASE_DIR: &str = ".3l_node";
+
+fn main() {
+    let environment = env::args().nth(1).unwrap_or("local".to_string());
+    let hash = match env::args().nth(2) {
+        None => {
+            println!("A payment hash must be provided");
+            return;
+        }
+        Some(h) => h,
+    };
+
+    println!("Starting a handle_notification test run.");
+    println!("Environment: {environment}");
+    println!("Payment hash we are looking for: {hash}");
+    println!();
+
+    let base_dir = format!("{BASE_DIR}_{environment}");
+
+    let environment = map_environment_code(&environment);
+
+    let seed = read_seed_from_env();
+
+    let config = Config {
+        environment,
+        seed,
+        fiat_currency: "EUR".to_string(),
+        local_persistence_path: base_dir.clone(),
+        timezone_config: TzConfig {
+            timezone_id: String::from("Africa/Tunis"),
+            timezone_utc_offset_secs: 60 * 60,
+        },
+        enable_file_logging: true,
+    };
+
+    let notification_payload = format!(
+        "{{
+         \"template\": \"payment_received\",
+         \"data\": {{
+          \"payment_hash\": \"{hash}\"
+         }}
+        }}"
+    );
+
+    let action =
+        handle_notification(config, notification_payload, Duration::from_secs(60)).unwrap();
+
+    println!("The recommended action is {action:?}");
+}
+
+fn read_seed_from_env() -> Vec<u8> {
+    let mnemonic = env!("BREEZ_SDK_MNEMONIC");
+    let mnemonic = mnemonic.split_whitespace().map(String::from).collect();
+    mnemonic_to_secret(mnemonic, "".to_string()).unwrap().seed
+}
+
+fn map_environment_code(code: &str) -> EnvironmentCode {
+    match code {
+        "local" => EnvironmentCode::Local,
+        "dev" => EnvironmentCode::Dev,
+        "stage" => EnvironmentCode::Stage,
+        "prod" => EnvironmentCode::Prod,
+        code => panic!("Unknown environment code: `{code}`"),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ mod lnurl;
 mod locker;
 mod logger;
 mod migrations;
+mod notification_handling;
 mod offer;
 mod random;
 mod recovery;
@@ -85,6 +86,7 @@ use crate::task_manager::TaskManager;
 use crate::util::{
     replace_byte_arrays_by_hex_string, unix_timestamp_to_system_time, LogIgnoreError,
 };
+pub use notification_handling::{handle_notification, Notification, RecommendedAction};
 
 pub use breez_sdk_core::error::ReceiveOnchainError as SwapError;
 use breez_sdk_core::error::{LnUrlWithdrawError, ReceiveOnchainError, SendPaymentError};

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -592,7 +592,7 @@ namespace lipalightninglib {
     void parse_lightning_address([ByRef] string address);
 
     [Throws=LnError]
-    RecommendedAction handle_notification(Config config, string notification_payload, duration timeout);
+    RecommendedAction handle_notification(Config config, string notification_payload);
 };
 
 dictionary Secret {

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -609,7 +609,7 @@ interface RecommendedAction {
 
 [Enum]
 interface Notification {
-    Bolt11PaymentReceived(u64 amount_sat, string hash);
+    Bolt11PaymentReceived(u64 amount_sat, string payment_hash);
 };
 
 //

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -590,12 +590,26 @@ namespace lipalightninglib {
 
     [Throws=ParseError]
     void parse_lightning_address([ByRef] string address);
+
+    [Throws=LnError]
+    RecommendedAction handle_notification(Config config, string notification_payload, duration timeout);
 };
 
 dictionary Secret {
     sequence<string> mnemonic;
     string passphrase;
     bytes seed;
+};
+
+[Enum]
+interface RecommendedAction {
+    None();
+    ShowNotification(Notification notification);
+};
+
+[Enum]
+interface Notification {
+    Bolt11PaymentReceived(u64 amount_sat, string hash);
 };
 
 //

--- a/src/notification_handling.rs
+++ b/src/notification_handling.rs
@@ -64,7 +64,9 @@ pub fn handle_notification(
     let (tx, rx) = mpsc::channel();
     let event_listener = Box::new(NotificationHandlerEventListener { event_sender: tx });
     let environment = Environment::load(config.environment);
-    let sdk = start_sdk(&rt, &config, &environment, event_listener)?;
+    let sdk = rt
+        .handle()
+        .block_on(start_sdk(&config, &environment, event_listener))?;
 
     match payload {
         Payload::PaymentReceived { payment_hash } => {

--- a/src/notification_handling.rs
+++ b/src/notification_handling.rs
@@ -1,15 +1,12 @@
 use crate::async_runtime::AsyncRuntime;
 use crate::environment::Environment;
 use crate::errors::Result;
-use crate::{enable_backtrace, Config, RuntimeErrorCode, EXEMPT_FEE, MAX_FEE_PERMYRIAD};
-use breez_sdk_core::{
-    BreezEvent, BreezServices, EventListener, GreenlightCredentials, GreenlightNodeConfig,
-    NodeConfig,
-};
+use crate::{enable_backtrace, start_sdk, Config};
+use breez_sdk_core::{BreezEvent, EventListener};
 use perro::{permanent_failure, MapToError};
 use serde::Deserialize;
+use std::sync::mpsc;
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
-use std::sync::{mpsc, Arc};
 use std::time::{Duration, Instant};
 
 /// A notification to be displayed to the user.
@@ -18,9 +15,12 @@ pub enum Notification {
     /// The notification that a previously issued bolt11 invoice was paid.
     /// The `amount_sat` of the payment is provided.
     ///
-    /// The `hash` can be used to directly open the associated [`Payment`](crate::Payment) using
+    /// The `payment_hash` can be used to directly open the associated [`Payment`](crate::Payment) using
     /// [`LightningNode::get_payment`](crate::LightningNode::get_payment).
-    Bolt11PaymentReceived { amount_sat: u64, hash: String },
+    Bolt11PaymentReceived {
+        amount_sat: u64,
+        payment_hash: String,
+    },
 }
 
 /// An action to be taken by the consumer of this library upon calling [`handle_notification`].
@@ -45,14 +45,15 @@ pub fn handle_notification(
 ) -> Result<RecommendedAction> {
     enable_backtrace();
 
-    let (tx, rx) = mpsc::channel();
+    let payload: Payload = serde_json::from_str(&notification_payload)
+        .map_to_invalid_input("Invalid notification payload")?;
 
     let rt = AsyncRuntime::new()?;
 
-    let _sdk = start_sdk(&rt, &config, tx)?;
-
-    let payload: Payload = serde_json::from_str(&notification_payload)
-        .map_to_invalid_input("Invalid notification payload")?;
+    let (tx, rx) = mpsc::channel();
+    let event_listener = Box::new(NotificationHandlerEventListener { event_sender: tx });
+    let environment = Environment::load(config.environment);
+    let _sdk = start_sdk(&rt, &config, &environment, event_listener)?;
 
     match payload {
         Payload::PaymentReceived { payment_hash } => {
@@ -70,10 +71,10 @@ fn handle_payment_received_notification(
     while Instant::now().duration_since(start) < timeout {
         let event = match event_receiver.recv_timeout(Duration::from_secs(1)) {
             Ok(e) => e,
+            Err(RecvTimeoutError::Timeout) => continue,
             Err(RecvTimeoutError::Disconnected) => {
                 permanent_failure!("The SDK stopped running unexpectedly");
             }
-            Err(_) => continue,
         };
 
         if let BreezEvent::InvoicePaid { details } = event {
@@ -81,7 +82,7 @@ fn handle_payment_received_notification(
                 return Ok(RecommendedAction::ShowNotification {
                     notification: Notification::Bolt11PaymentReceived {
                         amount_sat: details.payment.map(|p| p.amount_msat).unwrap_or(0) / 1000, // payment will only be None for corrupted GL payments. This is unlikely, so giving an optional amount seems overkill.
-                        hash: payment_hash,
+                        payment_hash,
                     },
                 });
             }
@@ -89,49 +90,6 @@ fn handle_payment_received_notification(
     }
 
     Ok(RecommendedAction::None)
-}
-
-fn start_sdk(
-    rt: &AsyncRuntime,
-    config: &Config,
-    event_sender: Sender<BreezEvent>,
-) -> Result<Arc<BreezServices>> {
-    let environment = Environment::load(config.environment);
-
-    let device_cert = env!("BREEZ_SDK_PARTNER_CERTIFICATE").as_bytes().to_vec();
-    let device_key = env!("BREEZ_SDK_PARTNER_KEY").as_bytes().to_vec();
-    let partner_credentials = GreenlightCredentials {
-        device_cert,
-        device_key,
-    };
-
-    let mut breez_config = BreezServices::default_config(
-        environment.environment_type.clone(),
-        env!("BREEZ_SDK_API_KEY").to_string(),
-        NodeConfig::Greenlight {
-            config: GreenlightNodeConfig {
-                partner_credentials: Some(partner_credentials),
-                invite_code: None,
-            },
-        },
-    );
-
-    breez_config.working_dir = config.local_persistence_path.clone();
-    breez_config.exemptfee_msat = EXEMPT_FEE.msats;
-    breez_config.maxfee_percent = MAX_FEE_PERMYRIAD as f64 / 100_f64;
-
-    let event_listener = Box::new(NotificationHandlerEventListener { event_sender });
-
-    rt.handle()
-        .block_on(BreezServices::connect(
-            breez_config,
-            config.seed.clone(),
-            event_listener,
-        ))
-        .map_to_runtime_error(
-            RuntimeErrorCode::NodeUnavailable,
-            "Failed to initialize a breez sdk instance",
-        )
 }
 
 #[derive(Deserialize)]

--- a/src/notification_handling.rs
+++ b/src/notification_handling.rs
@@ -1,0 +1,174 @@
+use crate::async_runtime::AsyncRuntime;
+use crate::environment::Environment;
+use crate::errors::Result;
+use crate::{enable_backtrace, Config, RuntimeErrorCode, EXEMPT_FEE, MAX_FEE_PERMYRIAD};
+use breez_sdk_core::{
+    BreezEvent, BreezServices, EventListener, GreenlightCredentials, GreenlightNodeConfig,
+    NodeConfig,
+};
+use perro::{permanent_failure, MapToError};
+use serde::Deserialize;
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
+use std::sync::{mpsc, Arc};
+use std::time::{Duration, Instant};
+
+/// A notification to be displayed to the user.
+pub enum Notification {
+    /// The notification that a previously issued bolt11 invoice was paid.
+    /// The `amount_sat` of the payment is provided.
+    ///
+    /// The `hash` can be used to directly open the associated [`Payment`](crate::Payment) using
+    /// [`LightningNode::get_payment`](crate::LightningNode::get_payment).
+    Bolt11PaymentReceived { amount_sat: u64, hash: String },
+}
+
+/// An action to be taken by the consumer of this library upon calling [`handle_notification`].
+pub enum RecommendedAction {
+    None,
+    ShowNotification { notification: Notification },
+}
+
+/// Handles a notification.
+///
+/// Notifications are used to wake up the node in order to process some request. Currently supported
+/// requests are:
+/// * Receive a payment from a previously issued bolt11 invoice.
+///
+/// The `timeout` is the maximum time this function will wait for the request to be processed.
+/// The node start-up time isn't included.
+pub fn handle_notification(
+    config: Config,
+    notification_payload: String,
+    timeout: Duration,
+) -> Result<RecommendedAction> {
+    enable_backtrace();
+
+    let (tx, rx) = mpsc::channel();
+
+    let rt = AsyncRuntime::new()?;
+
+    let _sdk = start_sdk(&rt, &config, tx)?;
+
+    let payload: Payload = serde_json::from_str(&notification_payload)
+        .map_to_invalid_input("Invalid notification payload")?;
+
+    match payload {
+        Payload::PaymentReceived { payment_hash } => {
+            handle_payment_received_notification(rx, payment_hash, timeout)
+        }
+    }
+}
+
+fn handle_payment_received_notification(
+    event_receiver: Receiver<BreezEvent>,
+    payment_hash: String,
+    timeout: Duration,
+) -> Result<RecommendedAction> {
+    let start = Instant::now();
+    while Instant::now().duration_since(start) < timeout {
+        let event = match event_receiver.recv_timeout(Duration::from_secs(1)) {
+            Ok(e) => e,
+            Err(RecvTimeoutError::Disconnected) => {
+                permanent_failure!("The SDK stopped running unexpectedly");
+            }
+            Err(_) => continue,
+        };
+
+        if let BreezEvent::InvoicePaid { details } = event {
+            if details.payment_hash == payment_hash {
+                return Ok(RecommendedAction::ShowNotification {
+                    notification: Notification::Bolt11PaymentReceived {
+                        amount_sat: details.payment.map(|p| p.amount_msat).unwrap_or(0) / 1000, // payment will only be None for corrupted GL payments. This is unlikely, so giving an optional amount seems overkill.
+                        hash: payment_hash,
+                    },
+                });
+            }
+        }
+    }
+
+    Ok(RecommendedAction::None)
+}
+
+fn start_sdk(
+    rt: &AsyncRuntime,
+    config: &Config,
+    event_sender: Sender<BreezEvent>,
+) -> Result<Arc<BreezServices>> {
+    let environment = Environment::load(config.environment);
+
+    let device_cert = env!("BREEZ_SDK_PARTNER_CERTIFICATE").as_bytes().to_vec();
+    let device_key = env!("BREEZ_SDK_PARTNER_KEY").as_bytes().to_vec();
+    let partner_credentials = GreenlightCredentials {
+        device_cert,
+        device_key,
+    };
+
+    let mut breez_config = BreezServices::default_config(
+        environment.environment_type.clone(),
+        env!("BREEZ_SDK_API_KEY").to_string(),
+        NodeConfig::Greenlight {
+            config: GreenlightNodeConfig {
+                partner_credentials: Some(partner_credentials),
+                invite_code: None,
+            },
+        },
+    );
+
+    breez_config.working_dir = config.local_persistence_path.clone();
+    breez_config.exemptfee_msat = EXEMPT_FEE.msats;
+    breez_config.maxfee_percent = MAX_FEE_PERMYRIAD as f64 / 100_f64;
+
+    let event_listener = Box::new(NotificationHandlerEventListener { event_sender });
+
+    rt.handle()
+        .block_on(BreezServices::connect(
+            breez_config,
+            config.seed.clone(),
+            event_listener,
+        ))
+        .map_to_runtime_error(
+            RuntimeErrorCode::NodeUnavailable,
+            "Failed to initialize a breez sdk instance",
+        )
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "template", content = "data")]
+#[serde(rename_all = "snake_case")]
+enum Payload {
+    PaymentReceived { payment_hash: String },
+}
+
+struct NotificationHandlerEventListener {
+    event_sender: Sender<BreezEvent>,
+}
+
+impl EventListener for NotificationHandlerEventListener {
+    fn on_event(&self, e: BreezEvent) {
+        let _ = self.event_sender.send(e);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::notification_handling::Payload;
+
+    const PAYMENT_RECEIVED_PAYLOAD_JSON: &str = r#"{
+                                                 "template": "payment_received",
+                                                 "data": {
+                                                  "payment_hash": "hash"
+                                                 }
+                                                }"#;
+
+    #[test]
+    pub fn test_payload_deserialize() {
+        let payment_received_payload: Payload =
+            serde_json::from_str(PAYMENT_RECEIVED_PAYLOAD_JSON).unwrap();
+        assert!(matches!(
+            payment_received_payload,
+            Payload::PaymentReceived {
+                payment_hash: hash
+            } if hash == "hash"
+        ));
+    }
+}

--- a/src/notification_handling.rs
+++ b/src/notification_handling.rs
@@ -13,6 +13,7 @@ use std::sync::{mpsc, Arc};
 use std::time::{Duration, Instant};
 
 /// A notification to be displayed to the user.
+#[derive(Debug)]
 pub enum Notification {
     /// The notification that a previously issued bolt11 invoice was paid.
     /// The `amount_sat` of the payment is provided.
@@ -23,6 +24,7 @@ pub enum Notification {
 }
 
 /// An action to be taken by the consumer of this library upon calling [`handle_notification`].
+#[derive(Debug)]
 pub enum RecommendedAction {
     None,
     ShowNotification { notification: Notification },


### PR DESCRIPTION
The implementation can be tested using the newly added example app.

Steps:
1. Start the regular example node, issue an invoice, and shut it down 
2. Run `make run-notification-handler <env> <payment hash of issued invoice>`
3. Do either of:
    * Don't pay the invoice or pay a different invoice -> after the timeout of 60 secs, the action `None` should be printed
    * Pay the invoice issued in step 1 -> the action `ShowNotification` should be printed
