### PR TITLE
Ignore topup test

### DIFF
--- a/tests/topup_test.rs
+++ b/tests/topup_test.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use serial_test::file_serial;
 use uniffi_lipalightninglib::{OfferInfo, OfferKind, OfferStatus};
 
+#[ignore]
 #[test]
 #[file_serial(key, path => "/tmp/3l-int-tests-lock")]
 fn test_topup() {


### PR DESCRIPTION
Pocket's staging API has suffered compatibility-breaking changes. Ignoring the test temporarily while it isn't fixed.