### PR TITLE
Prevent mock version to run on PROD backend

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -4,7 +4,7 @@ use hex::FromHex;
 use perro::MapToError;
 
 /// A code of the environment for the node to run.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum EnvironmentCode {
     Local,
     Dev,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,11 +317,17 @@ impl LightningNode {
         }
         info!("3L version: {}", env!("GITHUB_REF"));
 
+        #[cfg(feature = "mock-deps")]
+        if config.environment == EnvironmentCode::Prod {
+            permanent_failure!(
+                "The mocked version of 3L cannot be run in the PROD environment (backend)"
+            );
+        }
+
         let rt = AsyncRuntime::new()?;
 
         let environment = Environment::load(config.environment)?;
 
-        // TODO once we have mocked the backend, we can continue to use the seed from the config and still won't have conflicts with the real backend using the same seed
         #[cfg(not(feature = "mock-deps"))]
         let strong_typed_seed = sanitize_input::strong_type_seed(&config.seed)?;
 


### PR DESCRIPTION
Ensure the 3L mock-deps version is never run on the PROD backend