### PR TITLE
Remove fn from mock since its not used

### DIFF
--- a/mock/breez-sdk/src/lib.rs
+++ b/mock/breez-sdk/src/lib.rs
@@ -577,8 +577,4 @@ impl BreezServices {
     pub async fn register_webhook(&self, _webhook_url: String) -> SdkResult<()> {
         Ok(())
     }
-
-    pub async fn set_payment_metadata(&self, _hash: String, _metadata: String) -> SdkResult<()> {
-        todo!("set_payment_metadata");
-    }
 }


### PR DESCRIPTION
The personal note is now stored in the local db rather than as payment metadata with Breez-SDK