### PR TITLE
Add bump-wild procedure to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,13 @@ doc:
 .PHONY: pr
 pr: fmt buildall test clippy check-mod-test check-udl doc
 
+.PHONY: bump-wild
+bump-wild:
+	@newest_tag=$$(curl -s "https://api.github.com/repos/getlipa/wild/tags" | jq -r '.[0].name'); \
+	cargo_toml_files=$$(echo './Cargo.toml' ; find ./mock/wild/ -type f -name 'Cargo.toml'); \
+	echo "$$cargo_toml_files" | xargs sed -i "s/\(git = \"https:\/\/github.com\/getlipa\/wild\",\).*\(tag = \"[^\"]*\"\)/\1 tag = \"$$newest_tag\"/g"; \
+    echo "Bumped wild to $$newest_tag"; \
+
 .PHONY: run-node
 run-node: ARGS =
 run-node:


### PR DESCRIPTION
With more and more `wild` animals living in more and more places (base directory, mock directory), a little helper to bump the version of `wild` can come in handy.

The helper fetches the newest (version) tag from the `wild` repository and applies it to all relevant `Cargo.toml` files.
Just run:
`make bump-wild`