### PR TITLE
Enable topup test

### DIFF
--- a/tests/topup_test.rs
+++ b/tests/topup_test.rs
@@ -8,7 +8,6 @@ use std::time::Duration;
 use serial_test::file_serial;
 use uniffi_lipalightninglib::{OfferInfo, OfferKind, OfferStatus};
 
-#[ignore]
 #[test]
 #[file_serial(key, path => "/tmp/3l-int-tests-lock")]
 fn test_topup() {


### PR DESCRIPTION
Enables a test that was previously disabled in #942. A fix was applied in the backend.