### PR TITLE
Remove seed mock since backend is mocked now

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,17 +327,7 @@ impl LightningNode {
 
         let environment = Environment::load(config.environment)?;
 
-        #[cfg(not(feature = "mock-deps"))]
         let strong_typed_seed = sanitize_input::strong_type_seed(&config.seed)?;
-
-        #[cfg(feature = "mock-deps")]
-        let strong_typed_seed = {
-            let mut seed: [u8; 64] = [0; 64];
-            use rand::RngCore;
-            rand::thread_rng().fill_bytes(&mut seed);
-            seed
-        };
-
         let auth = Arc::new(build_auth(
             &strong_typed_seed,
             environment.backend_url.clone(),


### PR DESCRIPTION
Blocked by: https://github.com/getlipa/lipa-lightning-lib/pull/968

The backend is sufficiently mocked (not entirely, authentication and exchange rate are not mocked) that we can continue to use the same seed that's also used for a regular instance of 3L, without the danger of mixing data in the backend between the mock and the regular version.