### PR TITLE
Mock LNURL-withdraw service

### DIFF
--- a/mock/breez-sdk/src/lib.rs
+++ b/mock/breez-sdk/src/lib.rs
@@ -225,8 +225,7 @@ impl BreezServices {
         let payment_hash = format!("{:x}", sha256::Hash::hash(preimage.as_byte_array()));
         let payment_preimage = format!("{:x}", preimage);
         let bolt11 = "lnbc1pjlq2t3pp5e3ef7wmszlwxhfpx9cfnxx34gglg779fwnwx9mfm69pfapmymt0qdqqcqzzsxqyz5vqsp5x7k3pjq5y8vk473l6767fenletzwjeaqqukpg9tspfq584g8qp4q9qyyssq678xw6gf2ywl5seummdy8pc6xd0jpvzdexd4v4d3zjse9u6jf7239va4e4r4hhauqrymxu7dp790lv98dl0qhrt4yqxwll2ufkp304gqn6798s".to_string();
-        let payee_pubkey =
-            "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad".to_string();
+        let payee_pubkey = NODE_PUBKEY.to_string();
 
         let payment = Payment {
             id: now.to_string(), // Placeholder. ID is probably never used

--- a/mock/breez-sdk/src/lib.rs
+++ b/mock/breez-sdk/src/lib.rs
@@ -272,7 +272,7 @@ impl BreezServices {
                     payment_hash,
                     description: None,
                     description_hash: None,
-                    amount_msat: Some(30_000_000),
+                    amount_msat: Some(req.amount_msat),
                     timestamp: 0,
                     expiry: 0,
                     routing_hints: vec![],

--- a/mock/breez-sdk/src/lib.rs
+++ b/mock/breez-sdk/src/lib.rs
@@ -224,7 +224,7 @@ impl BreezServices {
         let preimage = sha256::Hash::hash(&now.to_be_bytes());
         let payment_hash = format!("{:x}", sha256::Hash::hash(preimage.as_byte_array()));
         let payment_preimage = format!("{:x}", preimage);
-        let bolt11 = "lnbc1486290n1pj74h6psp5tmna0gruf44rx0h7xgl2xsmn5xhjnaxktct40pkfg4m9kssytn0spp5qhpx9s8rvmw6jtzkelslve9zfuhpp2w7hn9s6q7xvdnds5jemr2qdpa2pskjepqw3hjq3r0deshgefqw3hjqjzjgcs8vv3qyq5y7unyv4ezqj2y8gszjxqy9ghlcqpjrzjqvutcqr0g2ltxthh82s8l24gy74xe862kelrywc6ktsx2gejgk26szcqygqqy6qqqyqqqqlgqqqq86qqyg9qxpqysgqzjnfufxw375gpqf9cvzd5jxyqqtm56fuw960wyel2ld3he403r7x6uyw59g5sfsj5rclycd09a8p8r2pnyrcanlg27e2a67nh5g248sp7p7s8z".to_string();
+        let bolt11 = "lnbc1pjlq2t3pp5e3ef7wmszlwxhfpx9cfnxx34gglg779fwnwx9mfm69pfapmymt0qdqqcqzzsxqyz5vqsp5x7k3pjq5y8vk473l6767fenletzwjeaqqukpg9tspfq584g8qp4q9qyyssq678xw6gf2ywl5seummdy8pc6xd0jpvzdexd4v4d3zjse9u6jf7239va4e4r4hhauqrymxu7dp790lv98dl0qhrt4yqxwll2ufkp304gqn6798s".to_string();
         let payee_pubkey =
             "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad".to_string();
 

--- a/src/fiat_topup.rs
+++ b/src/fiat_topup.rs
@@ -187,6 +187,7 @@ impl PocketClient {
             )
     }
 
+    #[cfg(not(feature = "mock-deps"))]
     fn create_order(
         &self,
         challenge_response: ChallengeResponse,
@@ -247,6 +248,46 @@ impl PocketClient {
                 RuntimeErrorCode::OfferServiceUnavailable,
                 "Failed to parse CreateOrderResponse",
             )
+    }
+
+    #[cfg(feature = "mock-deps")]
+    // todo: Instead of mocking this method only, we should move the entire PocketClient to a separate crate and mock the entire crate.
+    fn create_order(
+        &self,
+        _challenge_response: ChallengeResponse,
+        _user_iban: &str,
+        _user_currency: String,
+    ) -> Result<CreateOrderResponse> {
+        let now: DateTime<Utc> = Utc::now();
+        Ok(CreateOrderResponse {
+            id: format!("mock-order-id-{now}"),
+            active: true,
+            created_on: None,
+            affiliate_id: None,
+            fee_rate: 0.0,
+            payment_method: PaymentMethodResponse {
+                currency: "".to_string(),
+                debitor_iban: "".to_string(),
+                creditor_reference: "".to_string(),
+                creditor_iban: "".to_string(),
+                creditor_bank_name: "".to_string(),
+                creditor_bank_street: "".to_string(),
+                creditor_bank_postal_code: "".to_string(),
+                creditor_bank_town: "".to_string(),
+                creditor_bank_country: "".to_string(),
+                creditor_bank_bic: "".to_string(),
+                creditor_name: "".to_string(),
+                creditor_street: "".to_string(),
+                creditor_postal_code: "".to_string(),
+                creditor_town: "".to_string(),
+                creditor_country: "".to_string(),
+            },
+            payout_method: PayoutMethod {
+                node_pubkey: "".to_string(),
+                message: "".to_string(),
+                signature: "".to_string(),
+            },
+        })
     }
 
     fn sign_message(&self, message: String) -> Result<String> {


### PR DESCRIPTION
This can be tested as follows (env: dev/stage):

```bash
$      make run-node-mocked
3L ϟ   nodeinfo
3L ϟ   registertopup DK1125112511251125 eur test@lipa.swiss
3L ϟ   listoffers
3L ϟ   collectlastoffer
3L ϟ   nodeinfo      # check the difference
3L ϟ   listactivities
```