### PR TITLE
Mock: Implement deployment feedback

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -187,7 +187,7 @@ jobs:
           name: bindings-files-ios${{ matrix.mock-deps && '-mock' || '' }}
       - name: Create xcframework
         run: |
-          git clone git@github.com:getlipa/lipa-lightning-lib-swift.git
+          git clone git@github.com:getlipa/lipa-lightning-lib-swift${{ matrix.mock-deps && '_mock' || '' }}.git lipa-lightning-lib-swift
           cp bindings/swift/lipalightninglibFFI.h lipa-lightning-lib-swift/lipalightninglibFFI.xcframework/ios-arm64/lipalightninglibFFI.framework/Headers/lipalightninglibFFI.h
           cp bindings/swift/lipalightninglibFFI.h lipa-lightning-lib-swift/lipalightninglibFFI.xcframework/ios-arm64_x86_64-simulator/lipalightninglibFFI.framework/Headers/lipalightninglibFFI.h
           cp target/aarch64-apple-ios/release/libuniffi_lipalightninglib.a lipa-lightning-lib-swift/lipalightninglibFFI.xcframework/ios-arm64/lipalightninglibFFI.framework/lipalightninglibFFI

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -187,7 +187,7 @@ jobs:
           name: bindings-files-ios${{ matrix.mock-deps && '-mock' || '' }}
       - name: Create xcframework
         run: |
-          git clone git@github.com:getlipa/lipa-lightning-lib-swift${{ matrix.mock-deps && '_mock' || '' }}.git lipa-lightning-lib-swift
+          git clone git@github.com:getlipa/lipa-lightning-lib-swift.git
           cp bindings/swift/lipalightninglibFFI.h lipa-lightning-lib-swift/lipalightninglibFFI.xcframework/ios-arm64/lipalightninglibFFI.framework/Headers/lipalightninglibFFI.h
           cp bindings/swift/lipalightninglibFFI.h lipa-lightning-lib-swift/lipalightninglibFFI.xcframework/ios-arm64_x86_64-simulator/lipalightninglibFFI.framework/Headers/lipalightninglibFFI.h
           cp target/aarch64-apple-ios/release/libuniffi_lipalightninglib.a lipa-lightning-lib-swift/lipalightninglibFFI.xcframework/ios-arm64/lipalightninglibFFI.framework/lipalightninglibFFI

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -206,7 +206,7 @@ jobs:
           
           cp Package.swift.template Package.swift
           shasum -a 256 lipalightninglibFFI.xcframework.zip | sed 's/ .*//' > checksum
-          sed -i "s/to_replace_release_version/${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }}/g" Package.swift
+          sed -i "s/to_replace_release_version/${{ env.RELEASE_VERSION }}/g" Package.swift
           sed -i "s/to_replace_zip_checksum/$(cat checksum)/g" Package.swift
           
           git add Package.swift
@@ -223,9 +223,9 @@ jobs:
         if: ${{ env.BRANCH == 'main' }}
         run: |
           cd lipa-lightning-lib-swift
-          gh release create ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }} \
+          gh release create ${{ env.RELEASE_VERSION }} \
             lipalightninglibFFI.xcframework.zip \
-            --title "${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }}" \
+            --title "${{ env.RELEASE_VERSION }}" \
             --notes "This release was created automatically by the lipa bot. For more information, please access the corresponding release in https://github.com/getlipa/lipa-lightning-lib"
       - name: Create pre-release
         env:
@@ -233,9 +233,9 @@ jobs:
         if: ${{ env.BRANCH != 'main' }}
         run: |
           cd lipa-lightning-lib-swift
-          gh release create ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }} \
+          gh release create ${{ env.RELEASE_VERSION }} \
             lipalightninglibFFI.xcframework.zip \
-            --title "${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }}" \
+            --title "${{ env.RELEASE_VERSION }}" \
             --notes "This pre-release was created automatically by the lipa bot. For more information, please access the corresponding release in https://github.com/getlipa/lipa-lightning-lib" \
             --prerelease
 
@@ -315,7 +315,7 @@ jobs:
           shasum -a 256 jniLibs.zip | sed 's/ .*//' > checksum
 
           cp jitpack.yml.template jitpack.yml
-          sed -i "s/to_replace_release_version/${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }}/g" jitpack.yml
+          sed -i "s/to_replace_release_version/${{ env.RELEASE_VERSION }}/g" jitpack.yml
           sed -i "s/to_replace_zip_checksum/$(cat checksum)/g" jitpack.yml
 
           git add LipaLightningLib/src/main/java/com/getlipa/lipalightninglib/lipalightninglib.kt
@@ -331,9 +331,9 @@ jobs:
         if: ${{ env.BRANCH == 'main' }}
         run: |
           cd lipa-lightning-lib-android
-          gh release create ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }} \
+          gh release create ${{ env.RELEASE_VERSION }} \
             jniLibs.zip \
-            --title "${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }}" \
+            --title "${{ env.RELEASE_VERSION }}" \
             --notes "This release was created automatically by the lipa bot. For more information, please access the corresponding release in https://github.com/getlipa/lipa-lightning-lib"
       - name: Create pre-release
         env:
@@ -341,14 +341,14 @@ jobs:
         if: ${{ env.BRANCH != 'main' }}
         run: |
           cd lipa-lightning-lib-android
-          gh release create ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }} \
+          gh release create ${{ env.RELEASE_VERSION }} \
             jniLibs.zip \
-            --title "${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }}" \
+            --title "${{ env.RELEASE_VERSION }}" \
             --notes "This pre-release was created automatically by the lipa bot. For more information, please access the corresponding release in https://github.com/getlipa/lipa-lightning-lib" \
             --prerelease
       - name: Trigger JitPack build
         run: |
-          curl -s -m 30 https://jitpack.io/com/github/getlipa/lipa-lightning-lib-android/${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }} || true
+          curl -s -m 30 https://jitpack.io/com/github/getlipa/lipa-lightning-lib-android/${{ env.RELEASE_VERSION }} || true
 
   determine-branch:
     name: determine-branch

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -160,7 +160,7 @@ jobs:
           echo "BRANCH=$branch" >> $GITHUB_ENV
       - uses: webfactory/ssh-agent@v0.5.4
         with:
-          ssh-private-key: ${{ matrix.mock-deps && secrets.LIPA_BOT_IOS_MOCK_DEPLOY_KEY || secrets.LIPA_BOT_IOS_DEPLOY_KEY }}
+          ssh-private-key: ${{ secrets.LIPA_BOT_IOS_DEPLOY_KEY }}
       - name: Import bot's GPG key for signing commits
         id: import-gpg
         uses: crazy-max/ghaction-import-gpg@v4

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -160,7 +160,7 @@ jobs:
           echo "BRANCH=$branch" >> $GITHUB_ENV
       - uses: webfactory/ssh-agent@v0.5.4
         with:
-          ssh-private-key: ${{ secrets.LIPA_BOT_IOS_DEPLOY_KEY }}
+          ssh-private-key: ${{ matrix.mock-deps && secrets.LIPA_BOT_IOS_MOCK_DEPLOY_KEY || secrets.LIPA_BOT_IOS_DEPLOY_KEY }}
       - name: Import bot's GPG key for signing commits
         id: import-gpg
         uses: crazy-max/ghaction-import-gpg@v4

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - 'v*.*.*-mock*'
 
 env:
   GITHUB_REF: ${{ github.ref }}
@@ -214,7 +214,7 @@ jobs:
           git commit -m "This commit was created automatically by the lipa bot"
           git restore .
           git pull --rebase
-          git tag -a ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }} HEAD -m "This tag was created automatically by the lipa bot."
+          git tag -a ${{ env.RELEASE_VERSION }} HEAD -m "This tag was created automatically by the lipa bot."
           git push
           git push --tag
       - name: Create release
@@ -322,7 +322,7 @@ jobs:
           git add jitpack.yml
           git commit -m "This commit was created automatically by the lipa bot"
           git pull --rebase
-          git tag -a ${{ env.RELEASE_VERSION }}${{ matrix.mock-deps && '-mock' || '' }} HEAD -m "This tag was created automatically by the lipa bot."
+          git tag -a ${{ env.RELEASE_VERSION }} HEAD -m "This tag was created automatically by the lipa bot."
           git push
           git push --tag
       - name: Create release


### PR DESCRIPTION
~This PR deploys the mock artifact to its own [dedicated GitHub repo](https://github.com/getlipa/lipa-lightning-lib-swift_mock), rather than the [original one](https://github.com/getlipa/lipa-lightning-lib-swift).~

This PR also introduces explicit release tagging. That means, that from now on a mock release will have to be tagged on the `mock-deps` branch and with the suffix `-mock*` (for example `v0.41.7-beta-mock` or `v0.41.7-beta-mock2`). This would release a mock artifact _only_, while tagging a new version on `main` will _only_ release a PROD artifact.

Check out the [Github Workflow test run](https://github.com/getlipa/lipa-lightning-lib/actions/runs/8375860060)