### PR TITLE
Decrypt phone number ln addresses in lnurl recipient field

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -332,6 +332,24 @@ impl NotificationHandlingErrorCode {
     }
 }
 
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum PhoneNumberAddressDecryptErrorCode {
+    InvalidLnAddress,
+    HexDecodingError,
+    DecryptionError,
+    Utf8ConversionError,
+}
+
+impl Display for PhoneNumberAddressDecryptErrorCode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+pub type PhoneNumberAddressDecryptError = perro::Error<PhoneNumberAddressDecryptErrorCode>;
+pub type PhoneNumberAddressDecryptResult<T> =
+    std::result::Result<T, PhoneNumberAddressDecryptError>;
+
 /// Enum representing possible errors why parsing could fail.
 #[derive(Debug, thiserror::Error)]
 pub enum ParseError {

--- a/src/notification_handling.rs
+++ b/src/notification_handling.rs
@@ -324,23 +324,18 @@ fn handle_lnurl_pay_request_notification(
         &persistence_encryption_key,
     ) {
         Ok(decrypted) => decrypted,
-        Err(e) => {
-            if matches!(
-                e,
-                perro::Error::RuntimeError {
-                    code: PhoneNumberAddressDecryptErrorCode::HexDecodingError,
-                    ..
-                } | perro::Error::RuntimeError {
-                    code: PhoneNumberAddressDecryptErrorCode::DecryptionError,
-                    ..
-                }
-            ) {
-                debug!("Recipient in LNURL pay request is likely a regular lightning address (not an encrypted phone number): {}", data.recipient);
-                data.recipient.clone()
-            } else {
-                debug!("Recipient in LNURL pay request is likely not a lightning address, but a basic LNURL-pay request: {}", data.recipient);
-                data.recipient.clone()
-            }
+        Err(perro::Error::RuntimeError {
+            code:
+                PhoneNumberAddressDecryptErrorCode::HexDecodingError
+                | PhoneNumberAddressDecryptErrorCode::DecryptionError,
+            ..
+        }) => {
+            debug!("Recipient in LNURL pay request is likely a regular lightning address (not an encrypted phone number): {}", data.recipient);
+            data.recipient.clone()
+        }
+        Err(_) => {
+            debug!("Recipient in LNURL pay request is likely not a lightning address, but a basic LNURL-pay request: {}", data.recipient);
+            data.recipient.clone()
         }
     };
 


### PR DESCRIPTION
The phone number in the LNURLp recipient field needs to be decrypted before it can be compared to locally stored phone number addresses