### PR TITLE
Stop using tee and just cat test.json

### DIFF
--- a/.github/workflows/monitoring-tests.yml
+++ b/.github/workflows/monitoring-tests.yml
@@ -47,6 +47,8 @@ jobs:
         with:
           path: .3l_local_test
           key: monitor-local-test-cache
+      - name: Cat test results
+        run: cat test.json
       - name: Check test result
         run: |
           if [ ${{ steps.monitortest.outcome }} == "failure" ]; then

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,7 @@ testregisternode:
 
 .PHONY: monitortest
 monitortest:
-	set -o pipefail
-	cargo +nightly test --test monitoring_test -- --test-threads=1 --ignored -Z unstable-options --report-time --format json | tee test.json
+	cargo +nightly test --test monitoring_test -- --test-threads=1 --ignored -Z unstable-options --report-time --format json > test.json
 
 .PHONY: testall
 testall: test integrationtests


### PR DESCRIPTION
Using `tee` was messing with how we detect if a test failed or not. 