### PR TITLE
Fix warning about filename collision when building pocket mock

### DIFF
--- a/mock/pocketclient/Cargo.toml
+++ b/mock/pocketclient/Cargo.toml
@@ -3,9 +3,6 @@ name = "pocketclient-mock"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-name = "pocketclient"
-
 [dependencies]
 perro = { git = "https://github.com/getlipa/perro", tag = "v1.2.0" }
 pocketclient = { path = "../../pocketclient" }

--- a/src/data_store.rs
+++ b/src/data_store.rs
@@ -3,10 +3,10 @@ use crate::errors::Result;
 use crate::migrations::migrate;
 use crate::{EnableStatus, ExchangeRate, OfferKind, PocketOfferError, TzConfig, UserPreferences};
 
+use crate::pocketclient::FiatTopupInfo;
 use chrono::{DateTime, Utc};
 use crow::{PermanentFailureCode, TemporaryFailureCode};
 use perro::MapToError;
-use pocketclient::FiatTopupInfo;
 use rusqlite::{backup, params, Connection, OptionalExtension, Params, Row};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -661,9 +661,9 @@ mod tests {
     use crate::{EnableStatus, ExchangeRate, OfferKind, PocketOfferError, UserPreferences};
 
     use crate::analytics::AnalyticsConfig;
+    use crate::pocketclient::FiatTopupInfo;
     use crow::TopupError::TemporaryFailure;
     use crow::{PermanentFailureCode, TemporaryFailureCode};
-    use pocketclient::FiatTopupInfo;
     use std::fs;
     use std::thread::sleep;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,15 @@ use crate::task_manager::TaskManager;
 use crate::util::{
     replace_byte_arrays_by_hex_string, unix_timestamp_to_system_time, LogIgnoreError,
 };
-pub use pocketclient::FiatTopupInfo;
-use pocketclient::PocketClient;
+
+#[cfg(not(feature = "mock-deps"))]
+#[allow(clippy::single_component_path_imports)]
+use pocketclient;
+#[cfg(feature = "mock-deps")]
+use pocketclient_mock as pocketclient;
+
+pub use crate::pocketclient::FiatTopupInfo;
+use crate::pocketclient::PocketClient;
 
 pub use breez_sdk_core::error::ReceiveOnchainError as SwapError;
 pub use breez_sdk_core::error::RedeemOnchainError as SweepError;


### PR DESCRIPTION
```sh
warning: output filename collision.
The lib target `pocketclient` in package `pocketclient-mock v0.1.0 (~/3l/mock/pocketclient)` has the same output filename as the lib target `pocketclient` in package `pocketclient v0.1.0 (~/3l/pocketclient)`. Colliding filename is: ~/3l/target/debug/libpocketclient.rlib The targets should have unique names.
Consider changing their names to be unique or compiling them separately. This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
```