### PR TITLE
Improve mocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,7 +512,7 @@ version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
 dependencies = [
- "bech32",
+ "bech32 0.9.1",
  "bitcoin_hashes 0.11.0",
  "bitcoinconsensus",
  "secp256k1 0.24.3",
@@ -520,7 +526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1945a5048598e4189e239d3f809b19bdad4845c4b2ba400d304d2dcf26d2c462"
 dependencies = [
  "base64 0.13.1",
- "bech32",
+ "bech32 0.9.1",
  "bitcoin-private",
  "bitcoin_hashes 0.12.0",
  "hex_lit",
@@ -689,6 +695,7 @@ name = "breez-sdk-mock"
 version = "0.6.1"
 dependencies = [
  "anyhow",
+ "bech32 0.11.0",
  "bitcoin 0.30.2",
  "breez-sdk-core",
  "chrono",
@@ -1678,7 +1685,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.21.7",
- "bech32",
+ "bech32 0.9.1",
  "bytes",
  "chacha20poly1305",
  "chrono",
@@ -2343,7 +2350,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb24878b0f4ef75f020976c886d9ad1503867802329cc963e0ab4623ea3b25c"
 dependencies = [
- "bech32",
+ "bech32 0.9.1",
  "bitcoin 0.29.2",
  "bitcoin_hashes 0.11.0",
  "lightning 0.0.118",
@@ -2357,7 +2364,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48634cf0441331ea1fefb09736aa9a02c11be18281db9e067dd7567805bf3d33"
 dependencies = [
- "bech32",
+ "bech32 0.9.1",
  "bitcoin 0.30.2",
  "lightning 0.0.120",
  "num-traits",
@@ -3178,6 +3185,7 @@ version = "0.1.0"
 dependencies = [
  "perro",
  "pocketclient",
+ "uuid",
 ]
 
 [[package]]
@@ -5048,6 +5056,7 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
+ "getrandom",
  "serde",
  "sha1_smol",
 ]

--- a/mock/breez-sdk/Cargo.toml
+++ b/mock/breez-sdk/Cargo.toml
@@ -14,6 +14,7 @@ breez-sdk-core = { git = "https://github.com/breez/breez-sdk", tag = "0.6.1" }
 chrono = { version = "0.4", features = [] }
 hex = "0.4.3"
 rand = { version = "0.8.5", features = [] }
+bech32 = "0.11.0"
 lightning = "0.0.120"
 lightning-invoice = "0.28.0"
 lazy_static = { version = "1.4.0", features = [] }

--- a/mock/breez-sdk/src/lib.rs
+++ b/mock/breez-sdk/src/lib.rs
@@ -532,7 +532,7 @@ impl BreezServices {
                 description_hash: None,
                 amount_msat: Some(req.amount_msat),
                 timestamp: Utc::now().timestamp() as u64,
-                expiry: 0,
+                expiry: 3600,
                 routing_hints: vec![],
                 payment_secret: Vec::from(SAMPLE_PAYMENT_SECRET.as_bytes()),
                 min_final_cltv_expiry_delta: 144,

--- a/mock/breez-sdk/src/lib.rs
+++ b/mock/breez-sdk/src/lib.rs
@@ -36,7 +36,7 @@ const SWAPPER_ROUTING_FEE_SAT: u64 = 150;
 const SWAP_TX_WEIGHT: u64 = 800;
 const SAT_PER_VBYTE: u64 = 12;
 const SWAP_FEE_PERCENTAGE: f64 = 0.5;
-const SWAP_ADDRESS_DUMMY: &str = "1BitcoinEaterAddressDontSendf59kuE";
+const SWAP_ADDRESS_DUMMY: &str = "bc1qftnnghhyhyegmzmh0t7uczysr05e3vx75t96y2";
 const SWAP_RECEIVED_SATS_ON_CHAIN: u64 = 100_000;
 const TX_ID_DUMMY: &str = "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16";
 

--- a/mock/pocketclient/Cargo.toml
+++ b/mock/pocketclient/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 perro = { git = "https://github.com/getlipa/perro", tag = "v1.2.0" }
 pocketclient = { path = "../../pocketclient" }
+uuid = { version = "1.10.0", features = ["v4"] }

--- a/mock/pocketclient/src/lib.rs
+++ b/mock/pocketclient/src/lib.rs
@@ -1,5 +1,6 @@
 pub use pocketclient::{FiatTopupInfo, Result};
 use std::future::Future;
+use uuid::Uuid;
 
 pub struct PocketClient {}
 
@@ -20,7 +21,7 @@ impl PocketClient {
         Fut: Future<Output = Option<String>>,
     {
         Ok(FiatTopupInfo {
-            order_id: "Mock order_id".to_string(),
+            order_id: Uuid::new_v4().to_string(),
             debitor_iban: "Mock debitor_iban".to_string(),
             creditor_reference: "Mock creditor_reference".to_string(),
             creditor_iban: "Mock creditor_iban".to_string(),


### PR DESCRIPTION
Making the mock ready to be used for integration tests.

Requires documentation updates after release.
After this PR:
- real LNURL input is required to test LNURL
- `bc1qftnnghhyhyegmzmh0t7uczysr05e3vx75t96y2` is being used as swap address, instead of `1BitcoinEaterAddressDontSendf59kuE`