### PR TITLE
Improve swap mock and fix unit conversion bug

### DIFF
--- a/src/amount.rs
+++ b/src/amount.rs
@@ -14,6 +14,10 @@ impl Sats {
             msats: sats * 1000,
         }
     }
+
+    pub(crate) fn msats(&self) -> Msats {
+        Msats { msats: self.msats }
+    }
 }
 
 pub(crate) struct Msats {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2210,7 +2210,10 @@ impl LightningNode {
 
                 Ok((sent_amount, onchain_fee))
             };
-        self.get_onchain_resolving_fees(failed_swap_info.amount.sats.as_msats(), prepare_onchain_tx)
+        self.get_onchain_resolving_fees(
+            failed_swap_info.amount.sats.as_sats().msats(),
+            prepare_onchain_tx,
+        )
     }
 
     fn get_onchain_resolving_fees<F>(


### PR DESCRIPTION
Swap mocking changes:
- Swaps no longer change status automatically after a certain interval -> Now they can be managed using new commands (through invoice description)
- When refunding a swap, if the target address is our own swap address, a new one is started

Fixed bug:

- We were providing a sat amount to `get_onchain_resolving_fees`, which expects an msat amount. This has been fixed.