### PR TITLE
Remove swap txid

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1123,12 +1123,6 @@ impl LightningNode {
                         + in_progress_swap.confirmed_sats)
                         .as_sats()
                         .to_amount_down(&self.get_exchange_rate()),
-                    txid: in_progress_swap
-                        .unconfirmed_tx_ids
-                        .first()
-                        .or(in_progress_swap.confirmed_tx_ids.first())
-                        .ok_or(permanent_failure("In-progress swap doesn't have any txids"))?
-                        .clone(),
                 },
             })
         }
@@ -1350,11 +1344,6 @@ impl LightningNode {
                 created_at: unix_timestamp_to_system_time(s.created_at as u64)
                     .with_timezone(tz_config.clone()),
                 paid_amount: s.paid_msat.as_msats().to_amount_down(&exchange_rate),
-                txid: s
-                    .confirmed_tx_ids
-                    .first()
-                    .ok_or(permanent_failure("Confirmed swap has no confirmed txid"))?
-                    .clone(),
             };
             let incoming_payment_info = IncomingPaymentInfo::new(
                 breez_payment,

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -585,7 +585,6 @@ dictionary SwapInfo {
     string bitcoin_address;
     TzTime created_at;
     Amount paid_amount;
-    string txid;
 };
 
 dictionary ReverseSwapInfo {

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -10,7 +10,6 @@ pub struct SwapInfo {
     pub bitcoin_address: String,
     pub created_at: TzTime,
     pub paid_amount: Amount,
-    pub txid: String,
 }
 
 /// Information about a generated swap address


### PR DESCRIPTION
`confirmed_tx_ids` only includes txs that are confirmed and unspent, meaning that we can't get the txid after the swap is redeemed. 