### PR TITLE
Monitoring test adjustments

### DIFF
--- a/.github/workflows/monitoring-tests.yml
+++ b/.github/workflows/monitoring-tests.yml
@@ -2,7 +2,7 @@ name: Monitoring Tests
 
 on:
   schedule:
-    - cron: '21 2 * * *' # every day at 2:21 AM UTC
+    - cron: '0 */6 * * *' # At minute 0 past every 6th hour
   workflow_dispatch: # allow manually triggering a run
 
 

--- a/tests/monitoring_test.rs
+++ b/tests/monitoring_test.rs
@@ -22,6 +22,8 @@ const INVOICE_DESCRIPTION: &str = "automated bolt11 test";
 
 const TIME_RESULTS_FILE_NAME: &str = "test_times.json";
 
+const DELAY_BEFORE_ACTION: Duration = Duration::from_secs(10);
+
 struct TransactingNode {
     node: LightningNode,
     sent_payment_receiver: Receiver<String>,
@@ -167,6 +169,7 @@ fn exchange_rate_can_be_fetched_and_is_recent() {
 #[file_serial(key, path => "/tmp/3l-int-tests-lock")]
 fn invoice_can_be_created() {
     let sender = TransactingNode::new(NodeType::Sender).unwrap();
+    sleep(DELAY_BEFORE_ACTION);
     let start = Instant::now();
     sender
         .node
@@ -224,6 +227,7 @@ fn payments_can_be_performed() {
 
     let payment_hash = send_invoice.payment_hash.clone();
 
+    sleep(DELAY_BEFORE_ACTION);
     let start = Instant::now();
     sender
         .node


### PR DESCRIPTION
- Adds a delay before starting a timed action to prevent the measured time from being affected by a slow starting GL node
- Increases run frequency to every 6 hours