### PR TITLE
Run all integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test:
 integrationtests: FILE = *
 integrationtests: TEST = ''
 integrationtests:
-	cargo test --no-default-features --features mock-deps --workspace --test '$(FILE)' -- --ignored $(TEST)
+	cargo test --no-default-features --features mock-deps --workspace --test '$(FILE)' -- --include-ignored $(TEST)
 
 .PHONY: e2etests
 e2etests: FILE = *


### PR DESCRIPTION
Apparently the `--ignored` flag chooses _only_ the ignored tests to run.

So we haven't run most of our tests for a while.