### PR TITLE
Use longer lived lsp fee offers for redeeming

### DIFF
--- a/examples/node/cli.rs
+++ b/examples/node/cli.rs
@@ -632,10 +632,7 @@ fn calculate_swap_lsp_fee(
         .ok_or(anyhow!("Amount in SAT is required"))?
         .parse()
         .context("Amount should be a positive integer number")?;
-    let response = node
-        .onchain()
-        .swap()
-        .calculate_swap_lsp_fee_for_amount(amount)?;
+    let response = node.onchain().swap().calculate_lsp_fee_for_amount(amount)?;
     println!("LSP fee for Swaps: {}", amount_to_string(&response.lsp_fee));
     Ok(())
 }

--- a/examples/node/cli.rs
+++ b/examples/node/cli.rs
@@ -364,7 +364,7 @@ fn setup_editor(history_path: &Path) -> Editor<CommandHinter, DefaultHistory> {
     hints.insert(CommandHint::new("walletpubkeyid", "walletpubkeyid"));
     hints.insert(CommandHint::new("lspfee", "lspfee"));
     hints.insert(CommandHint::new(
-        "calculatelspfee <amount in SAT>",
+        "calculatelspfee <amount in SAT> [expiry in seconds]",
         "calculatelspfee ",
     ));
     hints.insert(CommandHint::new("exchangerates", "exchangerates"));
@@ -608,7 +608,17 @@ fn calculate_lsp_fee(node: &LightningNode, words: &mut dyn Iterator<Item = &str>
         .ok_or(anyhow!("Amount in SAT is required"))?
         .parse()
         .context("Amount should be a positive integer number")?;
-    let response = node.lightning().calculate_lsp_fee_for_amount(amount)?;
+    let expiry: Option<u32> = words
+        .next()
+        .map(|expiry| {
+            expiry
+                .parse()
+                .context("Expiry should be a positive integer number")
+        })
+        .transpose()?;
+    let response = node
+        .lightning()
+        .calculate_lsp_fee_for_amount(amount, expiry)?;
     println!(" LSP fee: {}", amount_to_string(&response.lsp_fee));
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -638,13 +638,8 @@ impl LightningNode {
     ///
     /// Requires network: **yes**
     #[deprecated = "lightning().calculate_lsp_fee_for_amount() should be used instead"]
-    pub fn calculate_lsp_fee(
-        &self,
-        amount_sat: u64,
-        expiry: Option<u32>,
-    ) -> Result<CalculateLspFeeResponse> {
-        self.lightning
-            .calculate_lsp_fee_for_amount(amount_sat, expiry)
+    pub fn calculate_lsp_fee(&self, amount_sat: u64) -> Result<CalculateLspFeeResponse> {
+        self.lightning.calculate_lsp_fee_for_amount(amount_sat)
     }
 
     /// Get the current limits for the amount that can be transferred in a single payment.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -625,13 +625,9 @@ impl LightningNode {
 
     /// Calculate the actual LSP fee for the given amount of an incoming payment.
     /// If the already existing inbound capacity is enough, no new channel is required.
-    /// The LSP may offer multiple fee rates, tied to different expiration dates.
-    /// Increased expiry dates mean higher fee rates.
-    /// This method returns the best offer within the given expiry.
     ///
     /// Parameters:
     /// * `amount_sat` - amount in sats to compute LSP fee for
-    /// * `expiry` - expiry time in seconds
     ///
     /// For the returned fees to be guaranteed to be accurate, the returned `lsp_fee_params` must be
     /// provided to [`LightningNode::create_invoice`]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -625,17 +625,26 @@ impl LightningNode {
 
     /// Calculate the actual LSP fee for the given amount of an incoming payment.
     /// If the already existing inbound capacity is enough, no new channel is required.
+    /// The LSP may offer multiple fee rates, tied to different expiration dates.
+    /// Increased expiry dates mean higher fee rates.
+    /// This method returns the best offer within the given expiry.
     ///
     /// Parameters:
     /// * `amount_sat` - amount in sats to compute LSP fee for
+    /// * `expiry` - expiry time in seconds
     ///
     /// For the returned fees to be guaranteed to be accurate, the returned `lsp_fee_params` must be
     /// provided to [`LightningNode::create_invoice`]
     ///
     /// Requires network: **yes**
     #[deprecated = "lightning().calculate_lsp_fee_for_amount() should be used instead"]
-    pub fn calculate_lsp_fee(&self, amount_sat: u64) -> Result<CalculateLspFeeResponse> {
-        self.lightning.calculate_lsp_fee_for_amount(amount_sat)
+    pub fn calculate_lsp_fee(
+        &self,
+        amount_sat: u64,
+        expiry: Option<u32>,
+    ) -> Result<CalculateLspFeeResponse> {
+        self.lightning
+            .calculate_lsp_fee_for_amount(amount_sat, expiry)
     }
 
     /// Get the current limits for the amount that can be transferred in a single payment.

--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -129,16 +129,25 @@ impl Lightning {
 
     /// Calculate the actual LSP fee for the given amount of an incoming payment.
     /// If the already existing inbound capacity is enough, no new channel is required.
+    /// The LSP may offer multiple fee rates, tied to different expiration dates.
+    /// Increased expiry dates mean higher fee rates.
+    /// This method returns the best offer within the given expiry.
     ///
     /// Parameters:
     /// * `amount_sat` - amount in sats to compute LSP fee for
+    /// * `expiry` - expiry time in seconds
     ///
     /// For the returned fees to be guaranteed to be accurate, the returned `lsp_fee_params` must be
     /// provided to [`Bolt11::create`]
     ///
     /// Requires network: **yes**
-    pub fn calculate_lsp_fee_for_amount(&self, amount_sat: u64) -> Result<CalculateLspFeeResponse> {
-        self.support.calculate_lsp_fee_for_amount(amount_sat)
+    pub fn calculate_lsp_fee_for_amount(
+        &self,
+        amount_sat: u64,
+        expiry: Option<u32>,
+    ) -> Result<CalculateLspFeeResponse> {
+        self.support
+            .calculate_lsp_fee_for_amount(amount_sat, expiry)
     }
 
     /// When *receiving* payments, a new channel MAY be required. A fee will be charged to the user.

--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -136,7 +136,7 @@ impl Lightning {
     /// For the returned fees to be guaranteed to be accurate, the returned `lsp_fee_params` must be
     /// provided to [`Bolt11::create`]
     ///
-    /// For swaps, use [`Swap::calculate_swap_lsp_fee_for_amount`] instead,
+    /// For swaps, use [`Swap::calculate_lsp_fee_for_amount`] instead,
     /// which uses fee offer from the LSP that is valid for a longer time period
     ///
     /// Requires network: **yes**

--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -129,25 +129,19 @@ impl Lightning {
 
     /// Calculate the actual LSP fee for the given amount of an incoming payment.
     /// If the already existing inbound capacity is enough, no new channel is required.
-    /// The LSP may offer multiple fee rates, tied to different expiration dates.
-    /// Increased expiry dates mean higher fee rates.
-    /// This method returns the best offer within the given expiry.
     ///
     /// Parameters:
     /// * `amount_sat` - amount in sats to compute LSP fee for
-    /// * `expiry` - expiry time in seconds
     ///
     /// For the returned fees to be guaranteed to be accurate, the returned `lsp_fee_params` must be
     /// provided to [`Bolt11::create`]
     ///
+    /// For swaps, use [`Swap::calculate_swap_lsp_fee_for_amount`] instead,
+    /// which uses fee offer from the LSP that is valid for a longer time period
+    ///
     /// Requires network: **yes**
-    pub fn calculate_lsp_fee_for_amount(
-        &self,
-        amount_sat: u64,
-        expiry: Option<u32>,
-    ) -> Result<CalculateLspFeeResponse> {
-        self.support
-            .calculate_lsp_fee_for_amount(amount_sat, expiry)
+    pub fn calculate_lsp_fee_for_amount(&self, amount_sat: u64) -> Result<CalculateLspFeeResponse> {
+        self.support.calculate_lsp_fee_for_amount(amount_sat, None)
     }
 
     /// When *receiving* payments, a new channel MAY be required. A fee will be charged to the user.

--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -136,7 +136,7 @@ impl Lightning {
     /// For the returned fees to be guaranteed to be accurate, the returned `lsp_fee_params` must be
     /// provided to [`Bolt11::create`]
     ///
-    /// For swaps, use [`Swap::calculate_lsp_fee_for_amount`] instead,
+    /// For swaps, use [`Swap::calculate_lsp_fee_for_amount`](crate::Swap::calculate_lsp_fee_for_amount) instead,
     /// which uses fee offer from the LSP that is valid for a longer time period
     ///
     /// Requires network: **yes**

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -327,7 +327,7 @@ interface Swap {
     SwapAddressInfo create(OpeningFeeParams? lsp_fee_params);
 
     [Throws=LnError]
-    CalculateLspFeeResponse calculate_swap_lsp_fee_for_amount(u64 amount_sat);
+    CalculateLspFeeResponse calculate_lsp_fee_for_amount(u64 amount_sat);
 
     [Throws=LnError]
     OnchainResolvingFees? determine_resolving_fees(FailedSwapInfo failed_swap_info);

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -16,7 +16,7 @@ interface LightningNode {
     PaymentAmountLimits get_payment_amount_limits();
 
     [Throws=LnError]
-    CalculateLspFeeResponse calculate_lsp_fee(u64 amount_sat, u32? expiry);
+    CalculateLspFeeResponse calculate_lsp_fee(u64 amount_sat);
 
     [Throws=LnError]
     InvoiceDetails create_invoice(u64 amount_sat, OpeningFeeParams? lsp_fee_params, string description, InvoiceCreationMetadata metadata);
@@ -252,7 +252,7 @@ interface Lightning {
     ReceiveAmountLimits determine_receive_amount_limits();
 
     [Throws=LnError]
-    CalculateLspFeeResponse calculate_lsp_fee_for_amount(u64 amount_sat, u32? expiry);
+    CalculateLspFeeResponse calculate_lsp_fee_for_amount(u64 amount_sat);
 
     [Throws=LnError]
     LspFee get_lsp_fee();
@@ -325,6 +325,9 @@ interface Onchain {
 interface Swap {
     [Throws=SwapError]
     SwapAddressInfo create(OpeningFeeParams? lsp_fee_params);
+
+    [Throws=LnError]
+    CalculateLspFeeResponse calculate_swap_lsp_fee_for_amount(u64 amount_sat);
 
     [Throws=LnError]
     OnchainResolvingFees? determine_resolving_fees(FailedSwapInfo failed_swap_info);

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -16,7 +16,7 @@ interface LightningNode {
     PaymentAmountLimits get_payment_amount_limits();
 
     [Throws=LnError]
-    CalculateLspFeeResponse calculate_lsp_fee(u64 amount_sat);
+    CalculateLspFeeResponse calculate_lsp_fee(u64 amount_sat, u32? expiry);
 
     [Throws=LnError]
     InvoiceDetails create_invoice(u64 amount_sat, OpeningFeeParams? lsp_fee_params, string description, InvoiceCreationMetadata metadata);
@@ -252,7 +252,7 @@ interface Lightning {
     ReceiveAmountLimits determine_receive_amount_limits();
 
     [Throws=LnError]
-    CalculateLspFeeResponse calculate_lsp_fee_for_amount(u64 amount_sat);
+    CalculateLspFeeResponse calculate_lsp_fee_for_amount(u64 amount_sat, u32? expiry);
 
     [Throws=LnError]
     LspFee get_lsp_fee();

--- a/src/onchain/channel_closes.rs
+++ b/src/onchain/channel_closes.rs
@@ -244,7 +244,7 @@ impl ChannelClose {
 
         let lsp_fees = self
             .swap
-            .calculate_swap_lsp_fee_for_amount(send_amount_sats)
+            .calculate_lsp_fee_for_amount(send_amount_sats)
             .map_err(|_| RedeemOnchainError::ServiceConnectivity {
                 err: "Could not get lsp fees".to_string(),
             })?

--- a/src/onchain/channel_closes.rs
+++ b/src/onchain/channel_closes.rs
@@ -239,7 +239,7 @@ impl ChannelClose {
 
         let lsp_fees = self
             .support
-            .calculate_lsp_fee_for_amount(send_amount_sats)
+            .calculate_lsp_fee_for_amount(send_amount_sats, None)
             .map_err(|_| RedeemOnchainError::ServiceConnectivity {
                 err: "Could not get lsp fees".to_string(),
             })?

--- a/src/onchain/channel_closes.rs
+++ b/src/onchain/channel_closes.rs
@@ -238,8 +238,8 @@ impl ChannelClose {
         }
 
         let lsp_fees = self
-            .support
-            .calculate_lsp_fee_for_amount(send_amount_sats, None)
+            .swap
+            .calculate_swap_lsp_fee_for_amount(send_amount_sats)
             .map_err(|_| RedeemOnchainError::ServiceConnectivity {
                 err: "Could not get lsp fees".to_string(),
             })?

--- a/src/onchain/channel_closes.rs
+++ b/src/onchain/channel_closes.rs
@@ -66,7 +66,12 @@ impl ChannelClose {
             ))
         };
 
-        get_onchain_resolving_fees(&self.support, onchain_balance, prepare_onchain_tx)
+        get_onchain_resolving_fees(
+            &self.support,
+            &self.swap,
+            onchain_balance,
+            prepare_onchain_tx,
+        )
     }
 
     /// Prepares a sweep of all available on-chain funds to the provided on-chain address.

--- a/src/onchain/mod.rs
+++ b/src/onchain/mod.rs
@@ -55,7 +55,7 @@ where
     F: FnOnce(String) -> Result<(Sats, Sats, u32)>,
 {
     let rate = support.get_exchange_rate();
-    let lsp_fees = swap.calculate_swap_lsp_fee_for_amount(amount.msats)?;
+    let lsp_fees = swap.calculate_lsp_fee_for_amount(amount.msats)?;
 
     let swap_info = support
         .rt
@@ -87,7 +87,7 @@ where
         return Ok(None);
     }
 
-    let lsp_fees = swap.calculate_swap_lsp_fee_for_amount(amount.msats)?;
+    let lsp_fees = swap.calculate_lsp_fee_for_amount(amount.msats)?;
 
     if swap_info.is_none()
         || sent_amount.sats < (swap_info.clone().unwrap().min_allowed_deposit as u64)

--- a/src/onchain/mod.rs
+++ b/src/onchain/mod.rs
@@ -6,15 +6,13 @@ use crate::amount::{AsSats, Msats, Sats, ToAmount};
 use crate::errors::Result;
 use crate::onchain::channel_closes::ChannelClose;
 use crate::onchain::reverse_swap::ReverseSwap;
-use crate::onchain::swap::Swap;
+use crate::onchain::swap::{calculate_swap_lsp_fee_for_amount, Swap};
 use crate::support::Support;
 use crate::{OnchainResolvingFees, RuntimeErrorCode, SwapToLightningFees};
 use breez_sdk_core::ReceiveOnchainRequest;
 use log::error;
 use perro::MapToError;
 use std::sync::Arc;
-
-const TWO_WEEKS: u32 = 2 * 7 * 24 * 60 * 60;
 
 pub struct Onchain {
     swap: Arc<Swap>,
@@ -56,7 +54,7 @@ where
     F: FnOnce(String) -> Result<(Sats, Sats, u32)>,
 {
     let rate = support.get_exchange_rate();
-    let lsp_fees = support.calculate_lsp_fee_for_amount(amount.msats, Some(TWO_WEEKS))?;
+    let lsp_fees = calculate_swap_lsp_fee_for_amount(support, amount.msats)?;
 
     let swap_info = support
         .rt
@@ -88,7 +86,7 @@ where
         return Ok(None);
     }
 
-    let lsp_fees = support.calculate_lsp_fee_for_amount(sent_amount.sats, Some(TWO_WEEKS))?;
+    let lsp_fees = calculate_swap_lsp_fee_for_amount(support, amount.msats)?;
 
     if swap_info.is_none()
         || sent_amount.sats < (swap_info.clone().unwrap().min_allowed_deposit as u64)

--- a/src/onchain/mod.rs
+++ b/src/onchain/mod.rs
@@ -14,6 +14,8 @@ use log::error;
 use perro::MapToError;
 use std::sync::Arc;
 
+const TWO_WEEKS: u32 = 2 * 7 * 24 * 60 * 60;
+
 pub struct Onchain {
     swap: Arc<Swap>,
     reverse_swap: Arc<ReverseSwap>,
@@ -54,7 +56,7 @@ where
     F: FnOnce(String) -> Result<(Sats, Sats, u32)>,
 {
     let rate = support.get_exchange_rate();
-    let lsp_fees = support.calculate_lsp_fee_for_amount(amount.msats)?;
+    let lsp_fees = support.calculate_lsp_fee_for_amount(amount.msats, Some(TWO_WEEKS))?;
 
     let swap_info = support
         .rt
@@ -86,7 +88,7 @@ where
         return Ok(None);
     }
 
-    let lsp_fees = support.calculate_lsp_fee_for_amount(sent_amount.sats)?;
+    let lsp_fees = support.calculate_lsp_fee_for_amount(sent_amount.sats, Some(TWO_WEEKS))?;
 
     if swap_info.is_none()
         || sent_amount.sats < (swap_info.clone().unwrap().min_allowed_deposit as u64)

--- a/src/onchain/mod.rs
+++ b/src/onchain/mod.rs
@@ -6,7 +6,7 @@ use crate::amount::{AsSats, Msats, Sats, ToAmount};
 use crate::errors::Result;
 use crate::onchain::channel_closes::ChannelClose;
 use crate::onchain::reverse_swap::ReverseSwap;
-use crate::onchain::swap::{calculate_swap_lsp_fee_for_amount, Swap};
+use crate::onchain::swap::Swap;
 use crate::support::Support;
 use crate::{OnchainResolvingFees, RuntimeErrorCode, SwapToLightningFees};
 use breez_sdk_core::ReceiveOnchainRequest;
@@ -47,6 +47,7 @@ impl Onchain {
 
 fn get_onchain_resolving_fees<F>(
     support: &Support,
+    swap: &Swap,
     amount: Msats,
     prepare_onchain_tx: F,
 ) -> Result<Option<OnchainResolvingFees>>
@@ -54,7 +55,7 @@ where
     F: FnOnce(String) -> Result<(Sats, Sats, u32)>,
 {
     let rate = support.get_exchange_rate();
-    let lsp_fees = calculate_swap_lsp_fee_for_amount(support, amount.msats)?;
+    let lsp_fees = swap.calculate_swap_lsp_fee_for_amount(amount.msats)?;
 
     let swap_info = support
         .rt
@@ -86,7 +87,7 @@ where
         return Ok(None);
     }
 
-    let lsp_fees = calculate_swap_lsp_fee_for_amount(support, amount.msats)?;
+    let lsp_fees = swap.calculate_swap_lsp_fee_for_amount(amount.msats)?;
 
     if swap_info.is_none()
         || sent_amount.sats < (swap_info.clone().unwrap().min_allowed_deposit as u64)

--- a/src/onchain/swap.rs
+++ b/src/onchain/swap.rs
@@ -96,7 +96,7 @@ impl Swap {
         };
         get_onchain_resolving_fees(
             &self.support,
-            &self,
+            self,
             failed_swap_info.amount.sats.as_sats().msats(),
             prepare_onchain_tx,
         )

--- a/src/onchain/swap.rs
+++ b/src/onchain/swap.rs
@@ -233,8 +233,7 @@ impl Swap {
         );
 
         let lsp_fees = self
-            .support
-            .calculate_lsp_fee_for_amount(send_amount_sats, None)?
+            .calculate_swap_lsp_fee_for_amount(send_amount_sats)?
             .lsp_fee
             .sats;
         ensure!(

--- a/src/onchain/swap.rs
+++ b/src/onchain/swap.rs
@@ -96,6 +96,7 @@ impl Swap {
         };
         get_onchain_resolving_fees(
             &self.support,
+            &self,
             failed_swap_info.amount.sats.as_sats().msats(),
             prepare_onchain_tx,
         )
@@ -295,15 +296,9 @@ impl Swap {
         &self,
         amount_sat: u64,
     ) -> Result<CalculateLspFeeResponse> {
-        calculate_swap_lsp_fee_for_amount(&self.support, amount_sat)
+        self.support
+            .calculate_lsp_fee_for_amount(amount_sat, Some(TWO_WEEKS))
     }
-}
-
-pub fn calculate_swap_lsp_fee_for_amount(
-    support: &Support,
-    amount_sat: u64,
-) -> Result<CalculateLspFeeResponse> {
-    support.calculate_lsp_fee_for_amount(amount_sat, Some(TWO_WEEKS))
 }
 
 /// Information the resolution of a failed swap.

--- a/src/onchain/swap.rs
+++ b/src/onchain/swap.rs
@@ -234,7 +234,7 @@ impl Swap {
         );
 
         let lsp_fees = self
-            .calculate_swap_lsp_fee_for_amount(send_amount_sats)?
+            .calculate_lsp_fee_for_amount(send_amount_sats)?
             .lsp_fee
             .sats;
         ensure!(
@@ -292,10 +292,7 @@ impl Swap {
     /// * `amount_sat` - amount in sats to compute LSP fee for
     ///
     /// Requires network: **yes**
-    pub fn calculate_swap_lsp_fee_for_amount(
-        &self,
-        amount_sat: u64,
-    ) -> Result<CalculateLspFeeResponse> {
+    pub fn calculate_lsp_fee_for_amount(&self, amount_sat: u64) -> Result<CalculateLspFeeResponse> {
         self.support
             .calculate_lsp_fee_for_amount(amount_sat, Some(TWO_WEEKS))
     }

--- a/src/onchain/swap.rs
+++ b/src/onchain/swap.rs
@@ -232,7 +232,7 @@ impl Swap {
 
         let lsp_fees = self
             .support
-            .calculate_lsp_fee_for_amount(send_amount_sats)?
+            .calculate_lsp_fee_for_amount(send_amount_sats, None)?
             .lsp_fee
             .sats;
         ensure!(

--- a/src/support.rs
+++ b/src/support.rs
@@ -111,18 +111,26 @@ impl Support {
 
     /// Calculate the actual LSP fee for the given amount of an incoming payment.
     /// If the already existing inbound capacity is enough, no new channel is required.
+    /// The LSP may offer multiple fee rates, tied to different expiration dates.
+    /// Increased expiry dates mean higher fee rates.
+    /// This method returns the best offer within the given expiry.
     ///
     /// Parameters:
     /// * `amount_sat` - amount in sats to compute LSP fee for
+    /// * `expiry` - expiry time in seconds
     ///
     /// For the returned fees to be guaranteed to be accurate, the returned `lsp_fee_params` must be
     /// provided to [`Bolt11::create`]
     ///
     /// Requires network: **yes**
-    pub fn calculate_lsp_fee_for_amount(&self, amount_sat: u64) -> Result<CalculateLspFeeResponse> {
+    pub fn calculate_lsp_fee_for_amount(
+        &self,
+        amount_sat: u64,
+        expiry: Option<u32>,
+    ) -> Result<CalculateLspFeeResponse> {
         let req = OpenChannelFeeRequest {
             amount_msat: Some(amount_sat.as_sats().msats),
-            expiry: None,
+            expiry,
         };
         let res = self
             .rt

--- a/tests/receive_onchain_test.rs
+++ b/tests/receive_onchain_test.rs
@@ -26,7 +26,7 @@ fn test_receive_onchain() {
     let lsp_fee_high_expiry = node
         .onchain()
         .swap()
-        .calculate_swap_lsp_fee_for_amount(100000)
+        .calculate_lsp_fee_for_amount(100000)
         .unwrap();
     assert_ne!(
         lsp_fee.lsp_fee_params.clone().unwrap().valid_until,

--- a/tests/receive_onchain_test.rs
+++ b/tests/receive_onchain_test.rs
@@ -21,11 +21,12 @@ fn test_receive_onchain() {
 
     let lsp_fee = node
         .lightning()
-        .calculate_lsp_fee_for_amount(100000, None)
+        .calculate_lsp_fee_for_amount(100000)
         .unwrap();
     let lsp_fee_high_expiry = node
-        .lightning()
-        .calculate_lsp_fee_for_amount(100000, Some(2 * 7 * 24 * 6 * 6))
+        .onchain()
+        .swap()
+        .calculate_swap_lsp_fee_for_amount(100000)
         .unwrap();
     assert_ne!(
         lsp_fee.lsp_fee_params.clone().unwrap().valid_until,

--- a/tests/receive_onchain_test.rs
+++ b/tests/receive_onchain_test.rs
@@ -19,11 +19,28 @@ fn test_receive_onchain() {
     assert!(swap_info.address.starts_with("bc1"));
     assert!(swap_info.min_deposit.sats < swap_info.max_deposit.sats);
 
-    let lsp_fee_params = node
+    let lsp_fee = node
         .lightning()
-        .calculate_lsp_fee_for_amount(100000)
-        .unwrap()
-        .lsp_fee_params;
-    let swap_info = node.onchain().swap().create(lsp_fee_params).unwrap();
+        .calculate_lsp_fee_for_amount(100000, None)
+        .unwrap();
+    let lsp_fee_high_expiry = node
+        .lightning()
+        .calculate_lsp_fee_for_amount(100000, Some(2 * 7 * 24 * 6 * 6))
+        .unwrap();
+    assert_ne!(
+        lsp_fee.lsp_fee_params.clone().unwrap().valid_until,
+        lsp_fee_high_expiry
+            .lsp_fee_params
+            .clone()
+            .unwrap()
+            .valid_until
+    );
+    assert!(lsp_fee.lsp_fee.sats < lsp_fee_high_expiry.lsp_fee.sats);
+
+    let swap_info = node
+        .onchain()
+        .swap()
+        .create(lsp_fee.lsp_fee_params)
+        .unwrap();
     assert!(swap_info.address.starts_with("bc1"));
 }


### PR DESCRIPTION
An LSP may offer multiple fee rates, tied to different expiration dates.

This PR exposes this election offer-election in some places and uses opinionated values in others. 