### PR TITLE
Use fixed Rust version for clippy

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -49,7 +49,7 @@ jobs:
       - name: rust-toolchain
         uses: actions-rs/toolchain@v1.0.6
         with:
-          toolchain: stable
+          toolchain: 1.82.0
           components: clippy
       - name: Install Protoc
         uses: arduino/setup-protoc@v3


### PR DESCRIPTION
The newest version of `clippy` (`1.83.0`) is not happy with some code that UNIFFI generates for us.

This PR just sticks to an older version of `clippy` to remove this warning and keep notifications for required maintenance lower in the future.