### PR TITLE
Always use cached LSP fee params

### DIFF
--- a/examples/node/cli.rs
+++ b/examples/node/cli.rs
@@ -1004,7 +1004,7 @@ fn pay_open_invoice(node: &LightningNode, words: &mut dyn Iterator<Item = &str>)
 }
 
 fn get_swap_address(node: &LightningNode) -> Result<()> {
-    let swap_address_info = node.onchain().swap().create(None)?;
+    let swap_address_info = node.onchain().swap().create()?;
 
     println!("Swap Address Information:");
     println!("  Address             {}", swap_address_info.address);
@@ -1703,14 +1703,10 @@ fn swap_onchain_to_lightning(node: &LightningNode) -> Result<()> {
             "Channel funds cannot be resolved as they are too little"
         ))?;
 
-    let swap_fees = resolving_fees
-        .swap_fees
-        .ok_or(anyhow!("Swap isn't available, not enough on-chain funds"))?;
-
-    let txid = node.onchain().channel_close().swap(
-        resolving_fees.sats_per_vbyte,
-        Some(swap_fees.lsp_fee_params),
-    )?;
+    let txid = node
+        .onchain()
+        .channel_close()
+        .swap(resolving_fees.sats_per_vbyte)?;
 
     println!("Sweeping transaction: {txid}");
 

--- a/mock/breez-sdk/src/lib.rs
+++ b/mock/breez-sdk/src/lib.rs
@@ -24,9 +24,9 @@ const LSP_TIMELOCK_DELTA: u32 = 42;
 const LSP_MIN_HTLC_MSAT: i64 = 600;
 const LSP_ADDED_LIQUIDITY_ON_NEW_CHANNELS_MSAT: u64 = 50_000_000;
 const OPENING_FEE_PARAMS_MIN_MSAT: u64 = 5_000_000;
+const OPENING_FEE_PARAMS_MIN_MSAT_MORE_EXPENSIVE: u64 = 6_000_000;
 const OPENING_FEE_PARAMS_PROPORTIONAL: u32 = 50;
-const OPENING_FEE_PARAMS_VALID_UNTIL: &str = "2030-02-16T11:46:49Z";
-const OPENING_FEE_PARAMS_VALID_UNTIL_LONGER: &str = "2031-02-16T11:46:49Z";
+const OPENING_FEE_PARAMS_PROPORTIONAL_MORE_EXPENSIVE: u32 = 100;
 const OPENING_FEE_PARAMS_MAX_IDLE_TIME: u32 = 10000;
 const OPENING_FEE_PARAMS_MAX_CLIENT_TO_SELF_DELAY: u32 = 256;
 const OPENING_FEE_PARAMS_PROMISE: &str = "promite";
@@ -67,7 +67,7 @@ use breez_sdk_core::{
     RedeemOnchainFundsResponse, RefundResponse, ReverseSwapInfo, ReverseSwapPairInfo,
     SendPaymentResponse, ServiceHealthCheckResponse, SignMessageResponse, SwapInfo,
 };
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use hex::FromHex;
 use lazy_static::lazy_static;
 use tokio::runtime::Handle;
@@ -808,10 +808,11 @@ impl BreezServices {
             }
         };
 
+        let (in_two_hours, in_three_days) = get_lsp_fee_params_expiry_dates();
         let valid_until = if req.expiry.is_some() {
-            OPENING_FEE_PARAMS_VALID_UNTIL.to_string()
+            in_two_hours.to_rfc3339()
         } else {
-            OPENING_FEE_PARAMS_VALID_UNTIL_LONGER.to_string()
+            in_three_days.to_rfc3339()
         };
 
         Ok(OpenChannelFeeResponse {
@@ -1061,6 +1062,8 @@ impl BreezServices {
     }
 
     pub async fn lsp_info(&self) -> SdkResult<LspInformation> {
+        let (in_two_hours, in_three_days) = get_lsp_fee_params_expiry_dates();
+
         Ok(LspInformation {
             id: LSP_ID.to_string(),
             name: LSP_NAME.to_string(),
@@ -1073,14 +1076,24 @@ impl BreezServices {
             min_htlc_msat: LSP_MIN_HTLC_MSAT,
             lsp_pubkey: vec![],
             opening_fee_params_list: OpeningFeeParamsMenu {
-                values: vec![OpeningFeeParams {
-                    min_msat: OPENING_FEE_PARAMS_MIN_MSAT,
-                    proportional: OPENING_FEE_PARAMS_PROPORTIONAL,
-                    valid_until: OPENING_FEE_PARAMS_VALID_UNTIL.to_string(),
-                    max_idle_time: OPENING_FEE_PARAMS_MAX_IDLE_TIME,
-                    max_client_to_self_delay: OPENING_FEE_PARAMS_MAX_CLIENT_TO_SELF_DELAY,
-                    promise: OPENING_FEE_PARAMS_PROMISE.to_string(),
-                }],
+                values: vec![
+                    OpeningFeeParams {
+                        min_msat: OPENING_FEE_PARAMS_MIN_MSAT,
+                        proportional: OPENING_FEE_PARAMS_PROPORTIONAL,
+                        valid_until: in_two_hours.to_rfc3339(),
+                        max_idle_time: OPENING_FEE_PARAMS_MAX_IDLE_TIME,
+                        max_client_to_self_delay: OPENING_FEE_PARAMS_MAX_CLIENT_TO_SELF_DELAY,
+                        promise: OPENING_FEE_PARAMS_PROMISE.to_string(),
+                    },
+                    OpeningFeeParams {
+                        min_msat: OPENING_FEE_PARAMS_MIN_MSAT_MORE_EXPENSIVE,
+                        proportional: OPENING_FEE_PARAMS_PROPORTIONAL_MORE_EXPENSIVE,
+                        valid_until: in_three_days.to_rfc3339(),
+                        max_idle_time: OPENING_FEE_PARAMS_MAX_IDLE_TIME,
+                        max_client_to_self_delay: OPENING_FEE_PARAMS_MAX_CLIENT_TO_SELF_DELAY,
+                        promise: OPENING_FEE_PARAMS_PROMISE.to_string(),
+                    },
+                ],
             },
         })
     }
@@ -1497,6 +1510,14 @@ fn generate_2_hashes_raw() -> (sha256::Hash, sha256::Hash) {
     let hash1 = sha256::Hash::hash(&generate_32_random_bytes());
 
     (hash1, Hash::hash(hash1.as_byte_array()))
+}
+
+fn get_lsp_fee_params_expiry_dates() -> (DateTime<Utc>, DateTime<Utc>) {
+    let now = Utc::now();
+    let in_two_hours = now + Duration::from_secs(60 * 60 * 2);
+    let in_three_days = now + Duration::from_secs(60 * 60 * 24 * 3);
+
+    (in_two_hours, in_three_days)
 }
 
 struct MockPayment {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1247,9 +1247,9 @@ impl LightningNode {
     #[deprecated = "onchain().swaps().create() should be used instead"]
     pub fn generate_swap_address(
         &self,
-        lsp_fee_params: Option<OpeningFeeParams>,
+        _lsp_fee_params: Option<OpeningFeeParams>,
     ) -> std::result::Result<SwapAddressInfo, ReceiveOnchainError> {
-        self.onchain.swap().create(lsp_fee_params)
+        self.onchain.swap().create()
     }
 
     /// Lists all unresolved failed swaps. Each individual failed swap can be recovered
@@ -1369,11 +1369,9 @@ impl LightningNode {
         &self,
         failed_swap_info: FailedSwapInfo,
         sats_per_vbyte: u32,
-        lsp_fee_param: Option<OpeningFeeParams>,
+        _lsp_fee_param: Option<OpeningFeeParams>,
     ) -> Result<String> {
-        self.onchain
-            .swap()
-            .swap(failed_swap_info, sats_per_vbyte, lsp_fee_param)
+        self.onchain.swap().swap(failed_swap_info, sats_per_vbyte)
     }
 
     /// Returns the fees for resolving channel closes if there are enough funds to pay for fees.
@@ -1408,11 +1406,9 @@ impl LightningNode {
     pub fn swap_channel_close_funds_to_lightning(
         &self,
         sats_per_vbyte: u32,
-        lsp_fee_params: Option<OpeningFeeParams>,
+        _lsp_fee_params: Option<OpeningFeeParams>,
     ) -> std::result::Result<String, RedeemOnchainError> {
-        self.onchain
-            .channel_close()
-            .swap(sats_per_vbyte, lsp_fee_params)
+        self.onchain.channel_close().swap(sats_per_vbyte)
     }
 
     /// Prints additional debug information to the logs.

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -321,7 +321,7 @@ interface Onchain {
 
 interface Swap {
     [Throws=SwapError]
-    SwapAddressInfo create(OpeningFeeParams? lsp_fee_params);
+    SwapAddressInfo create();
 
     [Throws=LnError]
     CalculateLspFeeResponseV2 calculate_lsp_fee_for_amount(u64 amount_sat);
@@ -336,7 +336,7 @@ interface Swap {
     string sweep(SweepFailedSwapInfo sweep_failed_swap_info);
 
     [Throws=LnError]
-    string swap(FailedSwapInfo failed_swap_info, u32 sats_per_vbyte, OpeningFeeParams? lsp_fee_param);
+    string swap(FailedSwapInfo failed_swap_info, u32 sats_per_vbyte);
 
     [Throws=LnError]
     LspFee get_lsp_fee();
@@ -364,7 +364,7 @@ interface ChannelClose {
     string sweep(SweepChannelCloseInfo sweep_info);
 
     [Throws=SweepError]
-    string swap(u32 sats_per_vbyte, OpeningFeeParams? lsp_fee_params);
+    string swap(u32 sats_per_vbyte);
 };
 
 interface Activities {

--- a/src/support.rs
+++ b/src/support.rs
@@ -12,13 +12,13 @@ use crate::{
     OfferKind, RuntimeErrorCode, UserPreferences,
 };
 use breez_sdk_core::{
-    BreezServices, OpenChannelFeeRequest, OpeningFeeParams, ReportIssueRequest,
-    ReportPaymentFailureDetails, UnspentTransactionOutput,
+    BreezServices, OpeningFeeParams, ReportIssueRequest, ReportPaymentFailureDetails,
+    UnspentTransactionOutput,
 };
 use crow::OfferManager;
 use honeybadger::Auth;
 use log::{debug, Level};
-use perro::{MapToError, OptionToError};
+use perro::MapToError;
 use std::sync::{Arc, Mutex};
 
 #[allow(dead_code)]
@@ -107,74 +107,6 @@ impl Support {
         Ok(node_state.utxos)
     }
 
-    /// Query the LSP fee params that the LSP offers.
-    /// Increased expiry dates mean higher fee rates.
-    /// This method returns the best offer within the given expiry.
-    ///
-    /// Parameters:
-    /// * `expiry` - expiry time in seconds
-    ///
-    /// Requires network: **yes**
-    pub(crate) fn query_lsp_fee_params(&self, expiry: Option<u32>) -> Result<OpeningFeeParams> {
-        let req = OpenChannelFeeRequest {
-            amount_msat: None,
-            expiry,
-        };
-        let res = self
-            .rt
-            .handle()
-            .block_on(self.sdk.open_channel_fee(req))
-            .map_to_runtime_error(
-                RuntimeErrorCode::NodeUnavailable,
-                "Failed to compute opening channel fee",
-            )?;
-
-        Ok(res.fee_params)
-    }
-
-    /// Calculate the actual LSP fee for the given amount of an incoming payment.
-    /// If the already existing inbound capacity is enough, no new channel is required.
-    /// The LSP may offer multiple fee rates, tied to different expiration dates.
-    /// Increased expiry dates mean higher fee rates.
-    /// This method returns the best offer within the given expiry.
-    ///
-    /// Parameters:
-    /// * `amount_sat` - amount in sats to compute LSP fee for
-    /// * `expiry` - expiry time in seconds
-    ///
-    /// For the returned fees to be guaranteed to be accurate, the returned `lsp_fee_params` must be
-    /// provided to [`Bolt11::create`]
-    ///
-    /// Requires network: **yes**
-    pub fn calculate_lsp_fee_for_amount(
-        &self,
-        amount_sat: u64,
-        expiry: Option<u32>,
-    ) -> Result<CalculateLspFeeResponseV2> {
-        let amount_msat = Some(amount_sat.as_sats().msats);
-        let req = OpenChannelFeeRequest {
-            amount_msat,
-            expiry,
-        };
-        let res = self
-            .rt
-            .handle()
-            .block_on(self.sdk.open_channel_fee(req))
-            .map_to_runtime_error(
-                RuntimeErrorCode::NodeUnavailable,
-                "Failed to compute opening channel fee",
-            )?;
-        let fee_msat = res.fee_msat.ok_or_permanent_failure(
-            "Breez SDK open_channel_fee returned None lsp fee when provided with Some(amount_msat)",
-        )?;
-        let lsp_fee = fee_msat.as_msats().to_amount_up(&self.get_exchange_rate());
-
-        Ok(CalculateLspFeeResponseV2 {
-            lsp_fee,
-            lsp_fee_params: res.fee_params,
-        })
-    }
-
     /// Calculate the actual LSP fee for the given amount of an incoming payment,
     /// providing the fee params that the LSP offers.
     /// Returns 0 if no new channel is required.
@@ -184,7 +116,7 @@ impl Support {
     /// * `lsp_fee_param` - Fee terms offered by the LSP
     ///
     /// Requires network: **no**
-    pub(crate) fn calculate_lsp_fee_for_amount_locally(
+    pub(crate) fn calculate_lsp_fee_for_amount(
         &self,
         amount_sat: u64,
         lsp_fee_param: OpeningFeeParams,

--- a/tests/receive_onchain_test.rs
+++ b/tests/receive_onchain_test.rs
@@ -10,12 +10,12 @@ use serial_test::file_serial;
 fn test_receive_onchain() {
     let node = start_node().unwrap();
 
-    let swap_info = node.onchain().swap().create(None).unwrap();
+    let swap_info = node.onchain().swap().create().unwrap();
     assert!(swap_info.address.starts_with("bc1"));
     assert!(swap_info.min_deposit.sats < swap_info.max_deposit.sats);
 
     // Calling a second time isn't an issue because no swap has been started
-    let swap_info = node.onchain().swap().create(None).unwrap();
+    let swap_info = node.onchain().swap().create().unwrap();
     assert!(swap_info.address.starts_with("bc1"));
     assert!(swap_info.min_deposit.sats < swap_info.max_deposit.sats);
 
@@ -33,11 +33,4 @@ fn test_receive_onchain() {
         lsp_fee_high_expiry.lsp_fee_params.clone().valid_until
     );
     assert!(lsp_fee.lsp_fee.sats < lsp_fee_high_expiry.lsp_fee.sats);
-
-    let swap_info = node
-        .onchain()
-        .swap()
-        .create(Some(lsp_fee.lsp_fee_params))
-        .unwrap();
-    assert!(swap_info.address.starts_with("bc1"));
 }


### PR DESCRIPTION
- Uses the locally cached (and periodically updated) `lsp_fee_params` everywhere, instead of requesting a new one in some occasions
- Removes the possibility to provide `lsp_fee_params` for the library consumer: When we access the `lsp_fee_params` from cache rather than requesting it over a network call, there is nothing lost when getting it ourselves rather than retrieving it from the library consumer.