### PR TITLE
Fix ReverseSwap pending state

### DIFF
--- a/src/activity.rs
+++ b/src/activity.rs
@@ -95,8 +95,7 @@ impl Activity {
         } = self
         {
             return reverse_swap_info.status == ReverseSwapStatus::Initial
-                || reverse_swap_info.status == ReverseSwapStatus::InProgress
-                || reverse_swap_info.status == ReverseSwapStatus::CompletedSeen;
+                || reverse_swap_info.status == ReverseSwapStatus::InProgress;
         }
         if let Some(payment_info) = self.get_payment_info() {
             return payment_info.payment_state.is_pending();


### PR DESCRIPTION
From now on we consider a ReverseSwap to be complete once the on-chain TX has been broadcast (even if it does not have any confirmations yet).

This aligns our interpretation with the one from Breez-SDK itself.