### PR TITLE
Reset mocked CLI app on startup

### DIFF
--- a/examples/node/main.rs
+++ b/examples/node/main.rs
@@ -27,8 +27,12 @@ fn main() {
     let environment = env::args().nth(1).unwrap_or("local".to_string());
     let base_dir = format!("{BASE_DIR}_{environment}");
 
-    // Delete mock dir (helpful in case we are running mocked, harmless in other cases)
-    let _ = fs::remove_dir_all(format!("{base_dir}_mocked"));
+    #[cfg(feature = "mock-deps")]
+    let base_dir = {
+        let dir = format!("{base_dir}_mocked");
+        let _ = fs::remove_dir_all(dir.clone());
+        dir
+    };
 
     let environment_code = map_environment_code(&environment);
     let environment = Environment::load(environment_code);


### PR DESCRIPTION
- Use `[...]_mocked` directory for mocked CLI node
- Delete that directory on every startup to always have a fresh instance

This has always been desired behavior, but for some reason this functionality got lost. Probably do to migrating between towards and from a dedicated git branch in the past.