### PR TITLE
Discontinue differentiation between offer kinds

### DIFF
--- a/src/actions_required.rs
+++ b/src/actions_required.rs
@@ -124,7 +124,7 @@ impl ActionsRequired {
     /// Hides the topup with the given id. Can be called on expired topups so that they stop being returned
     /// by [`ActionsRequired::list`].
     ///
-    /// Topup id can be obtained from [`OfferKind::Pocket`](crate::OfferKind::Pocket).
+    /// Topup id can be obtained from [`Offer`](crate::Offer).
     ///
     /// Requires network: **yes**
     pub fn dismiss_topup(&self, id: String) -> Result<()> {

--- a/src/activities.rs
+++ b/src/activities.rs
@@ -357,14 +357,14 @@ impl Activities {
                     .remote_services_config
                     .lipa_lightning_domain,
             )?;
-            let offer_kind = fill_payout_fee(
+            let offer = fill_payout_fee(
                 offer,
                 incoming_payment_info.requested_amount.sats.as_msats(),
                 &exchange_rate,
             );
             Ok(Activity::OfferClaim {
                 incoming_payment_info,
-                offer_kind,
+                offer,
             })
         } else if let Some(ref s) = payment_details.swap_info {
             let swap_info = SwapInfo {

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -1,5 +1,5 @@
 use crate::payment::{IncomingPaymentInfo, OutgoingPaymentInfo, PaymentInfo};
-use crate::{Amount, OfferKind, SwapInfo, TzTime};
+use crate::{Amount, Offer, SwapInfo, TzTime};
 
 use crate::reverse_swap::ReverseSwapInfo;
 use breez_sdk_core::ReverseSwapStatus;
@@ -23,7 +23,7 @@ pub enum Activity {
     // Topup, referrals.
     OfferClaim {
         incoming_payment_info: IncomingPaymentInfo,
-        offer_kind: OfferKind,
+        offer: Offer,
     },
     /// An On-chain to Lightning swap.
     ///

--- a/src/lipalightninglib.udl
+++ b/src/lipalightninglib.udl
@@ -640,7 +640,7 @@ interface MaxRoutingFeeMode {
 interface Activity {
     IncomingPayment(IncomingPaymentInfo incoming_payment_info);
     OutgoingPayment(OutgoingPaymentInfo outgoing_payment_info);
-    OfferClaim(IncomingPaymentInfo incoming_payment_info, OfferKind offer_kind);
+    OfferClaim(IncomingPaymentInfo incoming_payment_info, Offer offer);
     Swap(IncomingPaymentInfo? incoming_payment_info, SwapInfo swap_info);
     ReverseSwap(OutgoingPaymentInfo outgoing_payment_info, ReverseSwapInfo reverse_swap_info);
     ChannelClose(ChannelCloseInfo channel_close_info);
@@ -748,7 +748,7 @@ interface ActionRequiredItem {
 };
 
 dictionary OfferInfo {
-    OfferKind offer_kind;
+    Offer offer;
     Amount amount;
     string? lnurlw;
     timestamp created_at;
@@ -787,18 +787,15 @@ interface PocketOfferError {
     );
 };
 
-[Enum]
-interface OfferKind {
-    Pocket(
-        string id,
-        ExchangeRate exchange_rate,
-        u64 topup_value_minor_units,
-        u64? topup_value_sats,
-        u64 exchange_fee_minor_units,
-        u16 exchange_fee_rate_permyriad,
-        Amount? lightning_payout_fee,
-        PocketOfferError? error
-    );
+dictionary Offer {
+    string id;
+    ExchangeRate exchange_rate;
+    u64 topup_value_minor_units;
+    u64? topup_value_sats;
+    u64 exchange_fee_minor_units;
+    u16 exchange_fee_rate_permyriad;
+    Amount? lightning_payout_fee;
+    PocketOfferError? error;
 };
 
 enum OfferStatus {

--- a/src/offer.rs
+++ b/src/offer.rs
@@ -18,35 +18,32 @@ pub enum OfferStatus {
     SETTLED,
 }
 
+/// Values are denominated in the fiat currency the user sent to the exchange.
+/// The currency code can be found in `exchange_rate`.
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub enum OfferKind {
-    /// An offer related to a topup using the Pocket exchange
-    /// Values are denominated in the fiat currency the user sent to the exchange.
-    /// The currency code can be found in `exchange_rate`.
-    Pocket {
-        id: String,
-        /// The exchange rate used by the exchange to exchange fiat to sats.
-        exchange_rate: ExchangeRate,
-        /// The original fiat amount sent to the exchange.
-        topup_value_minor_units: u64,
-        /// The sat amount after the exchange. Isn't available for topups collected before version v0.30.0-beta.
-        topup_value_sats: Option<u64>,
-        /// The fee paid to perform the exchange from fiat to sats.
-        exchange_fee_minor_units: u64,
-        /// The rate of the fee expressed in permyriad (e.g. 1.5% would be 150).
-        exchange_fee_rate_permyriad: u16,
-        /// Optional payout fees collected by pocket.
-        lightning_payout_fee: Option<Amount>,
-        /// The optional error that might have occurred in the offer withdrawal process.
-        error: Option<PocketOfferError>,
-    },
+pub struct Offer {
+    pub id: String,
+    /// The exchange rate used by the exchange to exchange fiat to sats.
+    pub exchange_rate: ExchangeRate,
+    /// The original fiat amount sent to the exchange.
+    pub topup_value_minor_units: u64,
+    /// The sat amount after the exchange. Isn't available for topups collected before version v0.30.0-beta.
+    pub topup_value_sats: Option<u64>,
+    /// The fee paid to perform the exchange from fiat to sats.
+    pub exchange_fee_minor_units: u64,
+    /// The rate of the fee expressed in permyriad (e.g. 1.5% would be 150).
+    pub exchange_fee_rate_permyriad: u16,
+    /// Optional payout fees collected by pocket.
+    pub lightning_payout_fee: Option<Amount>,
+    /// The optional error that might have occurred in the offer withdrawal process.
+    pub error: Option<PocketOfferError>,
 }
 
 /// Information on a funds offer that can be claimed
 /// using [`crate::LightningNode::request_offer_collection`].
 #[derive(Debug, PartialEq, Clone, Eq)]
 pub struct OfferInfo {
-    pub offer_kind: OfferKind,
+    pub offer: Offer,
     /// Amount available for withdrawal
     pub amount: Amount,
     /// The lnurlw string that will be used to withdraw this offer. Can be empty if the offer isn't
@@ -75,7 +72,7 @@ impl OfferInfo {
         };
 
         OfferInfo {
-            offer_kind: OfferKind::Pocket {
+            offer: Offer {
                 id: topup_info.id,
                 exchange_rate,
                 topup_value_minor_units: topup_info.topup_value_minor_units,

--- a/src/support.rs
+++ b/src/support.rs
@@ -8,8 +8,8 @@ use crate::phone_number::PhoneNumberPrefixParser;
 use crate::task_manager::TaskManager;
 use crate::util::LogIgnoreError;
 use crate::{
-    CalculateLspFeeResponseV2, ChannelsInfo, ExchangeRate, LightningNodeConfig, NodeInfo,
-    OfferKind, RuntimeErrorCode, UserPreferences,
+    CalculateLspFeeResponseV2, ChannelsInfo, ExchangeRate, LightningNodeConfig, NodeInfo, Offer,
+    RuntimeErrorCode, UserPreferences,
 };
 use breez_sdk_core::{
     BreezServices, OpeningFeeParams, ReportIssueRequest, ReportPaymentFailureDetails,
@@ -170,7 +170,7 @@ impl Support {
             .log_ignore_error(Level::Warn, "Failed to report issue");
     }
 
-    pub fn store_payment_info(&self, hash: &str, offer: Option<OfferKind>) {
+    pub fn store_payment_info(&self, hash: &str, offer: Option<Offer>) {
         let user_preferences = self.user_preferences.lock_unwrap().clone();
         let exchange_rates = self.get_exchange_rates();
         self.data_store


### PR DESCRIPTION
Instead this will be done by the backend, and we just treat every offer kind the same (for now)