### PR TITLE
Fix typo: Past tense form of <to broadcast>

### DIFF
--- a/examples/node/cli.rs
+++ b/examples/node/cli.rs
@@ -1053,7 +1053,7 @@ fn refund_failed_swap(node: &LightningNode, words: &mut dyn Iterator<Item = &str
         .swap()
         .sweep(resolve_failed_swap_info)
         .map_err(|e| anyhow!("Failed to resolve failed swap: {e}"))?;
-    println!("Successfully broadcasted refund transaction - txid: {txid}");
+    println!("Successfully broadcast refund transaction - txid: {txid}");
 
     Ok(())
 }

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -41,7 +41,7 @@ pub trait EventsCallback: Send + Sync {
     ///   this swap.
     fn swap_received(&self, payment_hash: String);
 
-    /// This callback will be called when a TX of an on-chain send has been broadcasted to the Bitcoin network.
+    /// This callback will be called when a TX of an on-chain send has been broadcast to the Bitcoin network.
     ///
     /// Parameters:
     /// * `reverse_swap_id` - can be used to find the [`Activity`](crate::Activity) corresponding to

--- a/src/reverse_swap.rs
+++ b/src/reverse_swap.rs
@@ -11,7 +11,7 @@ pub struct ReverseSwapInfo {
     /// The tx id of the claim tx, which is the final tx in the reverse swap flow, which send funds
     /// to the targeted on-chain address.
     ///
-    /// It will only be present once the claim tx is broadcasted.
+    /// It will only be present once the claim tx is broadcast.
     pub claim_txid: Option<String>,
     pub status: ReverseSwapStatus,
 }


### PR DESCRIPTION
Apparently `to cast` (and thus `to broadcast`) is an irregular verb.