### PR TITLE
Update deprecated set state commands for GH actions

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -385,10 +385,10 @@ jobs:
         id: set-var
         run: |
           if [[ $BRANCH_NAMES == *'main'* ]]; then
-            echo "::set-output name=is_main::true"
+            echo "is_main=true" >> $GITHUB_OUTPUT
             echo "Setting is_main to true"
           else
-            echo "::set-output name=is_main::false"
+            echo "is_main=false" >> $GITHUB_OUTPUT
             echo "Setting is_main to false"
           fi
 


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/